### PR TITLE
fix: scenario 51 deployment — use writable data dir

### DIFF
--- a/scenarios/51-bmw-iac/config/app.yaml
+++ b/scenarios/51-bmw-iac/config/app.yaml
@@ -18,7 +18,7 @@ modules:
     type: iac.state
     config:
       backend: filesystem
-      directory: /var/lib/workflow/iac-state
+      directory: /data/iac-state
 
   - name: bmw-database
     type: platform.do_database

--- a/scenarios/51-bmw-iac/k8s/app.yaml
+++ b/scenarios/51-bmw-iac/k8s/app.yaml
@@ -38,8 +38,6 @@ spec:
               mountPath: /config
             - name: data
               mountPath: /data
-            - name: iac-state
-              mountPath: /var/lib/workflow/iac-state
           readinessProbe:
             httpGet:
               path: /healthz
@@ -52,20 +50,6 @@ spec:
             name: app
         - name: data
           emptyDir: {}
-        - name: iac-state
-          persistentVolumeClaim:
-            claimName: iac-state
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: iac-state
-  namespace: wf-scenario-51
-spec:
-  accessModes: [ReadWriteOnce]
-  resources:
-    requests:
-      storage: 100Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- Use `/data/iac-state` instead of `/var/lib/workflow/iac-state` for IaC state dir
- Remove PVC (mock test doesn't need persistent state)
- Fixes permission denied on distroless nonroot container

## Test plan
- [x] 13/13 scenario tests passing on minikube

🤖 Generated with [Claude Code](https://claude.com/claude-code)