### PR TITLE
fix: validate scenario metadata yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,13 @@ jobs:
         pip install pyyaml
         passed=0
         failed=0
-        for config in scenarios/*/config/app.yaml; do
-          scenario=$(echo "$config" | cut -d/ -f2)
-          if python3 -c "import yaml; yaml.safe_load(open('$config'))" 2>/dev/null; then
+        for yaml_file in scenarios/*/config/app.yaml scenarios/*/scenario.yaml; do
+          scenario=$(echo "$yaml_file" | cut -d/ -f2)
+          label=${yaml_file#scenarios/$scenario/}
+          if python3 -c "import yaml; yaml.safe_load(open('$yaml_file'))" 2>/dev/null; then
             passed=$((passed + 1))
           else
-            echo "FAIL: $scenario — invalid YAML"
+            echo "FAIL: $scenario $label — invalid YAML"
             failed=$((failed + 1))
           fi
         done

--- a/scenarios/66-iac-multi-cloud/scenario.yaml
+++ b/scenarios/66-iac-multi-cloud/scenario.yaml
@@ -13,8 +13,8 @@ description: |
   No live cloud API calls — config-validation only.
 components:
   - wfctl (config validation)
-  - iac.provider (provider: aws + provider: digitalocean)
-  - iac.state (backend: memory)
+  - "iac.provider (provider: aws + provider: digitalocean)"
+  - "iac.state (backend: memory)"
   - infra.vpc
   - infra.database
   - infra.container_service

--- a/scenarios/68-ci-generator/scenario.yaml
+++ b/scenarios/68-ci-generator/scenario.yaml
@@ -15,7 +15,7 @@ description: |
   No live CI execution — config-validation and file-generation testing only.
 components:
   - wfctl (config validation)
-  - ci.generator (provider: github + provider: gitlab)
+  - "ci.generator (provider: github + provider: gitlab)"
   - step.ci_generate
   - step.ci_validate
   - step.ci_diff


### PR DESCRIPTION
## Summary
- extend CI YAML syntax validation to include `scenarios/*/scenario.yaml`
- fix existing metadata YAML quoting issues in scenarios 66 and 68

## Verification
- `python3` PyYAML parse of all `scenarios/*/scenario.yaml`: `scenario metadata yaml ok`
- CI-equivalent YAML syntax loop: `YAML syntax: 173 passed, 0 failed`
- `WORKFLOW_DIR=/Users/jon/workspace/.codex-worktrees/workflow-ci-main bash scripts/pre-push`: `Validation: 82/82 passed, 0 failed`
- `GOWORK=off go test ./...`: pass
