### PR TITLE
Define sanitized DNS portfolio export fixture

### DIFF
--- a/docs/backlog/workflow-dns-iac-and-compute.md
+++ b/docs/backlog/workflow-dns-iac-and-compute.md
@@ -4,17 +4,17 @@ This backlog preserves open work from the DNS/IaC and workflow-compute threads s
 
 ## DNS/IaC Scenarios
 
-- Add public hermetic replay coverage for DNS import and migration invariants.
+- Public hermetic replay coverage for DNS import and migration invariants shipped in scenario 88.
 - Add private live scenarios for Cloudflare, DigitalOcean, Namecheap, and Hover where credentials and disposable resources are available.
-- Define a sanitized export format for real DNS portfolios before committing replay fixtures.
-- Add regression coverage for NS delegation, MX records, SPF/DMARC TXT records, CNAMEs, and provider-specific TTL/priority normalization.
+- Sanitized `workflow.dns-portfolio.export.v1` fixture envelope shipped in scenario 88; future live exporters should emit this shape before fixtures are committed.
+- Scenario 88 covers NS delegation, MX records, SPF/DMARC TXT records, CNAMEs, documentation/example IP enforcement, and provider-specific TTL/priority normalization.
 
 ## Provider Plugins
 
-- Extend Cloudflare plugin beyond DNS zones if the Cloudflare Registrar API exposes safe domain transfer/list/status/name-server operations.
+- Cloudflare plugin now supports import-first `infra.domain` for registrar metadata and explicit auto-renew updates; transfer/purchase flows remain out of public replay scope.
 - Keep DigitalOcean DNS import outputs aligned with Cloudflare/Namecheap canonical DNS replay shape.
 - Add or document a Hover importer path. Hover has no official API, so live automation may remain private or best-effort.
-- Revisit Namecheap registrar-transfer support separately from DNS management.
+- Namecheap plugin now supports explicit `infra.domain_transfer` creation/status using the provider API; destructive or cancellation-style operations remain separate work.
 
 ## DNS Management UI
 

--- a/docs/plans/2026-05-24-dns-export-format-adversarial-review.md
+++ b/docs/plans/2026-05-24-dns-export-format-adversarial-review.md
@@ -1,0 +1,43 @@
+# DNS Export Format Adversarial Review
+
+### Adversarial Review Report
+
+**Phase:** plan
+**Artifact:** docs/plans/2026-05-24-dns-export-format.md
+**Status:** PASS
+
+**Findings (Critical):**
+- None.
+
+**Findings (Important):**
+- [Security / privacy] Private RFC1918 addresses can reveal internal topology and should not be accepted just because they are non-public. Recommendation: require documentation/example ranges only. Status: addressed by explicit TEST-NET and `2001:db8::/32` validation.
+- [User-intent drift] A public replay format could be mistaken for live import coverage. Recommendation: keep README and backlog explicit that live account import/export remains private scenario work. Status: addressed.
+- [Missing failure modes] TXT records can contain verification tokens and DKIM keys, while DMARC legitimately contains `p=` policy text. Recommendation: validate known verification markers and DKIM redaction without blocking DMARC policy records. Status: addressed.
+
+**Findings (Minor):**
+- [Simpler alternative] A README-only format would be simpler but non-enforceable. Recommendation: keep executable fixture checks.
+
+**Bug-class scan transcript:**
+
+| Class | Result | Note |
+|---|---|---|
+| Unstated assumptions | Clean | Assumptions are listed and scoped to public replay. |
+| Repo-precedent conflicts | Clean | Scenario-local Python validation matches existing local-only scenario style. |
+| YAGNI violations | Clean | No live exporter or provider mock process was added. |
+| Missing failure modes | Finding | TXT/DKIM and replay-vs-live boundaries were tightened. |
+| Security / privacy | Finding | Private IP acceptance was replaced with documentation/example-only validation. |
+| Rollback story | Clean | Revert-only rollback is enough for docs, fixture, and tests. |
+| Simpler alternative not considered | Finding | README-only alternative rejected because it lacks CI enforcement. |
+| User-intent drift | Finding | README/backlog now preserve live private scenario boundary. |
+| Over-decomposition / under-decomposition | Clean | Single scenario slice is appropriately small. |
+| Verification-class mismatch | Clean | Both direct and wrapper scenario tests are required. |
+| Hidden serial dependencies | Clean | Scenario already exists in `scenarios.json`; wrapper remains valid. |
+| Missing rollback wiring | Clean | No runtime rollback task is required. |
+
+**Options the author may not have considered:**
+
+1. Add a real sanitizer CLI now: useful later, but premature without a second fixture or private provider export source.
+2. Use JSON Schema: stronger formal validation, but would introduce dependency/tooling questions. The current Python validator is enough for this scenario.
+
+**Verdict reasoning:** PASS. The plan improves the replay scenario's safety boundary without claiming live provider coverage or adding an unproven exporter.
+

--- a/docs/plans/2026-05-24-dns-export-format.md
+++ b/docs/plans/2026-05-24-dns-export-format.md
@@ -1,0 +1,37 @@
+# DNS Export Format Plan
+
+## Goal
+
+Make scenario 88 define and enforce a sanitized DNS portfolio export envelope before real provider exports are committed as replay fixtures.
+
+## Approach
+
+Extend the existing `88-iac-dns-replay-migration` fixture from a generic replay document to `workflow.dns-portfolio.export.v1`. The envelope records sanitization status, non-sensitive source metadata, redaction rules, and forbidden source patterns. Keep the format provider-neutral so Cloudflare, DigitalOcean, Namecheap, Hover, and future private exporters can emit the same shape.
+
+Add validation for:
+
+- `metadata.sanitized: true` and `sanitization.status: sanitized`.
+- Required redaction rules for domain aliases, documentation/example IP addresses, TXT secret redaction, and email redaction.
+- Documentation/example-only A and AAAA values, not arbitrary private or public addresses.
+- Forbidden raw source strings absent from snapshots and migration plans.
+- `migration.apply_mode: plan_only` and `delete_unlisted: false`.
+
+Update scenario docs, metadata, and backlog to reflect shipped public coverage and remaining private/live work.
+
+## Assumptions
+
+- A fixture envelope is the right public next step before building live private exporters.
+- Replay fixtures must be safe to commit even if generated from real domain portfolios.
+- Provider plugins remain responsible for live import/apply behavior; this scenario validates the portable shape and safety invariants.
+
+## Rollback
+
+Rollback is to revert this docs/fixture/test change. No provider API, runtime service, deployment, or plugin loading path changes.
+
+## Verification
+
+- Watch the scenario fail before adding the missing envelope fields.
+- Run `bash scenarios/88-iac-dns-replay-migration/test/run.sh`.
+- Run `bash scripts/test.sh 88-iac-dns-replay-migration`.
+- Run `GOWORK=off go test ./...`.
+- Run `git diff --check`.

--- a/e2e/dns_replay_test.go
+++ b/e2e/dns_replay_test.go
@@ -21,10 +21,13 @@ func TestDNSReplayMigrationScenario(t *testing.T) {
 	}
 	text := string(output)
 	for _, want := range []string{
+		"PASS: fixture declares export schema v1",
+		"PASS: fixtures use only documentation/example IP addresses",
+		"PASS: TXT records redact verification tokens and DKIM public keys",
 		"PASS: provider coverage includes cloudflare",
 		"PASS: MX records are preserved in target",
 		"PASS: destructive deletes require explicit opt-in",
-		"Results: 123 passed, 0 failed",
+		"Results: 141 passed, 0 failed",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("DNS replay output missing %q\n%s", want, output)

--- a/scenarios.json
+++ b/scenarios.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-24T00:49:23.474853Z",
+  "lastUpdated": "2026-05-24T02:51:53.903292Z",
   "componentVersions": {
     "workflow": "v0.2.15",
     "workflow-cloud": "v0.1.0",
@@ -1054,12 +1054,12 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "testCount": 123,
-      "passCount": 123,
+      "testCount": 141,
+      "passCount": 141,
       "failCount": 0,
       "localOnly": true,
       "notes": "Offline replay scenario for DNS/IaC import and migration safety. Validates sanitized Cloudflare, DigitalOcean, Namecheap, and Hover snapshots without provider accounts.",
-      "lastTested": "2026-05-24T00:49:23.474394Z",
+      "lastTested": "2026-05-24T02:51:53.903292Z",
       "lastResult": "pass"
     }
   }

--- a/scenarios/88-iac-dns-replay-migration/README.md
+++ b/scenarios/88-iac-dns-replay-migration/README.md
@@ -2,16 +2,32 @@
 
 Offline replay scenario for DNS/IaC import and migration safety.
 
-The scenario does not call Cloudflare, DigitalOcean, Namecheap, Hover, or any registrar API. It validates sanitized snapshots that model imported provider state and a planned Cloudflare target zone.
+The scenario does not call Cloudflare, DigitalOcean, Namecheap, Hover, or any registrar API. It validates sanitized `workflow.dns-portfolio.export.v1` snapshots that model imported provider state and a planned Cloudflare target zone.
 
 ## What It Tests
 
 - Provider snapshot shape for Cloudflare, DigitalOcean, Namecheap, and Hover.
+- Export metadata marking the portfolio as sanitized before it can be used as a replay fixture.
 - NS authority metadata is present for source and target zones.
 - MX, SPF, DMARC, CNAME, A, and AAAA records survive normalization.
+- Documentation/example IP ranges are used instead of public or private production addresses.
+- TXT verification tokens and DKIM material are redacted before fixture commit.
 - Cloudflare target state exposes Cloudflare nameservers.
-- Destructive deletes are disabled unless explicitly opted in.
+- Destructive deletes are disabled unless explicitly opted in, and migration defaults to `plan_only`.
 - Migration plans track manual nameserver switch and MX-delivery verification steps.
+
+## Export Format
+
+Replay fixtures use `workflow.dns-portfolio.export.v1`:
+
+- `metadata.sanitized: true` is required.
+- `metadata.source_portfolio_id` must be a non-sensitive alias, not an account ID or real domain.
+- `sanitization.rules` records the transformations applied before commit.
+- `sanitization.forbidden_patterns` lists source-only strings that must not appear in the sanitized snapshots or migration plan.
+- `snapshots[]` contains provider, domain, authority metadata, and normalized DNS records.
+- `migration.apply_mode` must start as `plan_only`, with `delete_unlisted: false`.
+
+Live/private exporters should preserve provider record semantics while replacing domains with `.example` aliases, public and private addresses with documentation ranges, email addresses with `example.invalid`, and TXT verification or DKIM material with explicit redaction markers.
 
 ## What It Does Not Test
 
@@ -19,6 +35,7 @@ The scenario does not call Cloudflare, DigitalOcean, Namecheap, Hover, or any re
 - Registrar transfer execution.
 - Real DNS propagation.
 - Plugin process loading through `wfctl`.
+- Sanitizer execution against real account exports.
 
 Those belong in `workflow-scenarios-private` live scenarios with explicit credentials, budgets, cleanup, and disposable test resources.
 

--- a/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
+++ b/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
@@ -1,6 +1,29 @@
 {
-  "schema": "workflow.dns-replay.v1",
+  "schema": "workflow.dns-portfolio.export.v1",
   "description": "Sanitized DNS import and Cloudflare migration replay fixture.",
+  "metadata": {
+    "sanitized": true,
+    "generated_at": "2026-05-24T00:00:00Z",
+    "source_portfolio_id": "example-dns-portfolio",
+    "exporter": "workflow-scenarios/manual-fixture"
+  },
+  "sanitization": {
+    "status": "sanitized",
+    "rules": [
+      "domain_aliases",
+      "example_ip_addresses",
+      "txt_secret_redaction",
+      "email_redaction"
+    ],
+    "forbidden_patterns": [
+      "hover-source.test",
+      "do-authoritative.test",
+      "namecheap-managed.test",
+      "cloudflare-target.test",
+      "google-site-verification=",
+      "keybase-site-verification="
+    ]
+  },
   "snapshots": [
     {
       "id": "hover-source",
@@ -213,6 +236,7 @@
   "migration": {
     "source_snapshot": "hover-source",
     "target_snapshot": "cloudflare-target",
+    "apply_mode": "plan_only",
     "delete_unlisted": false,
     "required_manual_steps": [
       "verify_target_zone",

--- a/scenarios/88-iac-dns-replay-migration/scenario.yaml
+++ b/scenarios/88-iac-dns-replay-migration/scenario.yaml
@@ -2,10 +2,10 @@ name: IaC DNS Replay Migration
 id: "88-iac-dns-replay-migration"
 category: C
 description: |
-  Offline replay scenario for DNS/IaC import and migration safety.
-  Uses sanitized provider snapshots for Hover, DigitalOcean, Namecheap,
-  and Cloudflare to validate record preservation and destructive-change
-  guardrails without real provider accounts.
+  Offline replay scenario for DNS/IaC import and migration safety. Uses
+  sanitized workflow.dns-portfolio.export.v1 provider snapshots for Hover,
+  DigitalOcean, Namecheap, and Cloudflare to validate record preservation,
+  redaction, and destructive-change guardrails without real provider accounts.
 components:
   - workflow-scenarios replay fixture
   - iac.provider.cloudflare (target shape)
@@ -19,5 +19,6 @@ tags:
   - dns
   - import
   - migration
+  - sanitized-export
   - replay
   - local-only

--- a/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
+++ b/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
@@ -8,6 +8,12 @@ import json
 import sys
 from pathlib import Path
 
+EXAMPLE_IPV4_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in ("192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24")
+)
+EXAMPLE_IPV6_NETWORKS = (ipaddress.ip_network("2001:db8::/32"),)
+
 
 class Reporter:
     def __init__(self) -> None:
@@ -49,12 +55,13 @@ def canonical_record(record: dict, domain: str) -> tuple:
     return record_type, name, value, ttl, priority, proxied
 
 
-def is_reserved_address(value: str) -> bool:
+def is_example_address(value: str) -> bool:
     try:
         addr = ipaddress.ip_address(value)
     except ValueError:
-        return True
-    return addr.is_private or addr.is_loopback or addr.is_reserved
+        return False
+    networks = EXAMPLE_IPV6_NETWORKS if addr.version == 6 else EXAMPLE_IPV4_NETWORKS
+    return any(addr in network for network in networks)
 
 
 def load_fixture(path: Path, reporter: Reporter) -> dict | None:
@@ -69,6 +76,21 @@ def load_fixture(path: Path, reporter: Reporter) -> dict | None:
         return None
     reporter.pass_("fixture is valid JSON")
     return data
+
+
+def validate_export_envelope(data: dict, reporter: Reporter) -> None:
+    reporter.check(data.get("schema") == "workflow.dns-portfolio.export.v1", "fixture declares export schema v1")
+    metadata = data.get("metadata", {})
+    reporter.check(metadata.get("sanitized") is True, "fixture is explicitly marked sanitized")
+    reporter.check(bool(metadata.get("generated_at")), "fixture includes generation timestamp")
+    reporter.check(bool(metadata.get("source_portfolio_id")), "fixture includes non-sensitive source portfolio id")
+
+    sanitization = data.get("sanitization", {})
+    reporter.check(sanitization.get("status") == "sanitized", "sanitization status is sanitized")
+    rules = sanitization.get("rules", [])
+    for rule in ("domain_aliases", "example_ip_addresses", "txt_secret_redaction", "email_redaction"):
+        reporter.check(rule in rules, f"sanitization rule records {rule}")
+    reporter.check(isinstance(sanitization.get("forbidden_patterns"), list), "sanitization declares forbidden patterns")
 
 
 def validate_snapshot_shape(data: dict, reporter: Reporter) -> list[dict]:
@@ -96,9 +118,30 @@ def validate_sanitized_addresses(snapshots: list[dict], reporter: Reporter) -> N
         for record in snapshot.get("records", []):
             if str(record.get("type", "")).upper() in {"A", "AAAA"}:
                 value = str(record.get("value", record.get("data", "")))
-                if not is_reserved_address(value):
+                if not is_example_address(value):
                     unsafe.append((snapshot.get("id"), record.get("name"), value))
-    reporter.check(not unsafe, "fixtures use only reserved/example IP addresses")
+    reporter.check(not unsafe, "fixtures use only documentation/example IP addresses")
+
+
+def validate_redaction(data: dict, snapshots: list[dict], reporter: Reporter) -> None:
+    forbidden = [str(pattern).lower() for pattern in data.get("sanitization", {}).get("forbidden_patterns", [])]
+    serialized = json.dumps({"snapshots": snapshots, "migration": data.get("migration", {})}, sort_keys=True).lower()
+    for pattern in forbidden:
+        reporter.check(pattern not in serialized, f"fixture excludes forbidden pattern {pattern}")
+
+    txt_records = [
+        str(record.get("value", record.get("data", "")))
+        for snapshot in snapshots
+        for record in snapshot.get("records", [])
+        if str(record.get("type", "")).upper() == "TXT"
+    ]
+    secret_markers = ("google-site-verification=", "keybase-site-verification=")
+    leaked = [value for value in txt_records if any(marker in value.lower() for marker in secret_markers)]
+    leaked.extend(
+        value for value in txt_records
+        if "v=dkim1" in value.lower() and "<redacted>" not in value.lower()
+    )
+    reporter.check(not leaked, "TXT records redact verification tokens and DKIM public keys")
 
 
 def validate_provider_coverage(snapshots: list[dict], reporter: Reporter) -> None:
@@ -138,6 +181,7 @@ def validate_record_preservation(data: dict, snapshots: list[dict], reporter: Re
 def validate_migration_safety(data: dict, snapshots: list[dict], reporter: Reporter) -> None:
     migration = data.get("migration", {})
     reporter.check(migration.get("delete_unlisted") is False, "destructive deletes require explicit opt-in")
+    reporter.check(migration.get("apply_mode") == "plan_only", "migration defaults to plan-only apply mode")
 
     target = next((s for s in snapshots if s.get("id") == migration.get("target_snapshot")), {})
     nameservers = [str(ns).lower() for ns in target.get("authority", {}).get("name_servers", [])]
@@ -156,8 +200,10 @@ def main(argv: list[str]) -> int:
 
     data = load_fixture(Path(argv[1]), reporter)
     if data is not None:
+        validate_export_envelope(data, reporter)
         snapshots = validate_snapshot_shape(data, reporter)
         validate_sanitized_addresses(snapshots, reporter)
+        validate_redaction(data, snapshots, reporter)
         validate_provider_coverage(snapshots, reporter)
         validate_record_preservation(data, snapshots, reporter)
         validate_migration_safety(data, snapshots, reporter)

--- a/scripts/update-status.sh
+++ b/scripts/update-status.sh
@@ -12,9 +12,10 @@ import json, datetime
 with open('scenarios.json', 'r') as f:
     d = json.load(f)
 d['scenarios']['$SCENARIO']['deployed'] = '$VALUE' == 'true'
-d['lastUpdated'] = datetime.datetime.utcnow().isoformat() + 'Z'
+d['lastUpdated'] = datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z')
 with open('scenarios.json', 'w') as f:
     json.dump(d, f, indent=2)
+    f.write('\n')
 "
         ;;
     test)
@@ -27,15 +28,17 @@ import json, datetime
 with open('scenarios.json', 'r') as f:
     d = json.load(f)
 s = d['scenarios']['$SCENARIO']
-s['lastTested'] = datetime.datetime.utcnow().isoformat() + 'Z'
+now = datetime.datetime.now(datetime.UTC).isoformat().replace('+00:00', 'Z')
+s['lastTested'] = now
 s['lastResult'] = '$RESULT'
 s['testCount'] = $TOTAL
 s['passCount'] = $PASS
 s['failCount'] = $FAIL
 s['status'] = 'passed' if '$RESULT' == 'pass' else 'failed'
-d['lastUpdated'] = datetime.datetime.utcnow().isoformat() + 'Z'
+d['lastUpdated'] = now
 with open('scenarios.json', 'w') as f:
     json.dump(d, f, indent=2)
+    f.write('\n')
 "
         ;;
 esac


### PR DESCRIPTION
## Summary
- Promote scenario 88 replay data to the versioned `workflow.dns-portfolio.export.v1` fixture envelope.
- Enforce sanitized metadata, forbidden source patterns, documentation/example-only IPs, TXT secret redaction, and plan-only migration defaults.
- Update DNS/IaC backlog and fix the scenario status writer to use timezone-aware timestamps with trailing newlines.

## Verification
- Watched new scenario checks fail before adding the missing envelope fields.
- `bash scenarios/88-iac-dns-replay-migration/test/run.sh`
- `bash scripts/test.sh 88-iac-dns-replay-migration`
- `WORKFLOW_DIR=/Users/jon/workspace/workflow make validate`
- `git diff --check`

## Notes
- This remains public, account-free replay coverage. Live/provider-account export and registrar migration checks stay in private scenarios.