### PR TITLE
test: declare DNS provider output contracts

### DIFF
--- a/e2e/dns_replay_test.go
+++ b/e2e/dns_replay_test.go
@@ -25,9 +25,12 @@ func TestDNSReplayMigrationScenario(t *testing.T) {
 		"PASS: fixtures use only documentation/example IP addresses",
 		"PASS: TXT records redact verification tokens and DKIM public keys",
 		"PASS: provider coverage includes cloudflare",
+		"PASS: fixture declares provider output contracts",
+		"PASS: cloudflare output contract requires authority.name_servers",
+		"PASS: namecheap output contract requires authority.is_using_our_dns",
 		"PASS: MX records are preserved in target",
 		"PASS: destructive deletes require explicit opt-in",
-		"Results: 141 passed, 0 failed",
+		"Results: 176 passed, 0 failed",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("DNS replay output missing %q\n%s", want, output)

--- a/scenarios.json
+++ b/scenarios.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-24T02:51:53.903292Z",
+  "lastUpdated": "2026-05-24T04:35:31.745321Z",
   "componentVersions": {
     "workflow": "v0.2.15",
     "workflow-cloud": "v0.1.0",
@@ -1054,12 +1054,12 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "testCount": 141,
-      "passCount": 141,
+      "testCount": 176,
+      "passCount": 176,
       "failCount": 0,
       "localOnly": true,
       "notes": "Offline replay scenario for DNS/IaC import and migration safety. Validates sanitized Cloudflare, DigitalOcean, Namecheap, and Hover snapshots without provider accounts.",
-      "lastTested": "2026-05-24T02:51:53.903292Z",
+      "lastTested": "2026-05-24T04:35:31.745321Z",
       "lastResult": "pass"
     }
   }

--- a/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
+++ b/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
@@ -24,6 +24,76 @@
       "keybase-site-verification="
     ]
   },
+  "provider_output_contracts": {
+    "cloudflare": {
+      "resource_types": [
+        "infra.dns",
+        "infra.domain"
+      ],
+      "dns_required_outputs": [
+        "domain",
+        "records",
+        "record_count",
+        "name_servers",
+        "original_name_servers",
+        "authority",
+        "authority.name_servers",
+        "authority.original_name_servers",
+        "authority.original_registrar",
+        "authority.original_dnshost"
+      ],
+      "delete_unlisted_flag": "manage_unlisted",
+      "apply_semantics": "record_upsert_preserve_unlisted"
+    },
+    "digitalocean": {
+      "resource_types": [
+        "infra.dns"
+      ],
+      "dns_required_outputs": [
+        "domain",
+        "records",
+        "record_count",
+        "zone_file",
+        "authoritative_nameservers",
+        "authority",
+        "authority.name_servers"
+      ],
+      "delete_unlisted_flag": "unsupported",
+      "apply_semantics": "record_upsert_preserve_unlisted"
+    },
+    "namecheap": {
+      "resource_types": [
+        "infra.dns",
+        "infra.domain_transfer"
+      ],
+      "dns_required_outputs": [
+        "domain",
+        "record_count",
+        "email_type",
+        "is_using_our_dns",
+        "authority",
+        "authority.email_type",
+        "authority.is_using_our_dns"
+      ],
+      "delete_unlisted_flag": "implicit_in_whole_zone_replace",
+      "apply_semantics": "whole_zone_replace"
+    },
+    "hover": {
+      "resource_types": [
+        "infra.dns",
+        "infra.dns_delegation"
+      ],
+      "dns_required_outputs": [
+        "domain",
+        "records",
+        "record_count",
+        "authority",
+        "authority.name_servers"
+      ],
+      "delete_unlisted_flag": "unsupported",
+      "apply_semantics": "read_only_import"
+    }
+  },
   "snapshots": [
     {
       "id": "hover-source",

--- a/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
+++ b/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
@@ -150,6 +150,33 @@ def validate_provider_coverage(snapshots: list[dict], reporter: Reporter) -> Non
         reporter.check(provider in providers, f"provider coverage includes {provider}")
 
 
+def validate_provider_output_contracts(data: dict, reporter: Reporter) -> None:
+    contracts = data.get("provider_output_contracts", {})
+    reporter.check(isinstance(contracts, dict) and bool(contracts), "fixture declares provider output contracts")
+    required = {
+        "cloudflare": {"domain", "records", "record_count", "authority", "authority.name_servers", "authority.original_name_servers"},
+        "digitalocean": {"domain", "records", "record_count", "zone_file", "authority", "authority.name_servers"},
+        "namecheap": {"domain", "record_count", "authority", "authority.is_using_our_dns", "authority.email_type"},
+        "hover": {"domain", "records", "record_count", "authority", "authority.name_servers"},
+    }
+    for provider, required_paths in required.items():
+        contract = contracts.get(provider, {})
+        reporter.check(isinstance(contract, dict), f"{provider} output contract is an object")
+        resource_types = contract.get("resource_types", [])
+        reporter.check("infra.dns" in resource_types, f"{provider} output contract covers infra.dns")
+        paths = set(contract.get("dns_required_outputs", []))
+        for path in sorted(required_paths):
+            reporter.check(path in paths, f"{provider} output contract requires {path}")
+    cloudflare = contracts.get("cloudflare", {})
+    reporter.check(cloudflare.get("delete_unlisted_flag") == "manage_unlisted", "Cloudflare contract requires explicit manage_unlisted for destructive reconciliation")
+    digitalocean = contracts.get("digitalocean", {})
+    reporter.check(digitalocean.get("delete_unlisted_flag") == "unsupported", "DigitalOcean contract does not delete undeclared DNS records")
+    namecheap = contracts.get("namecheap", {})
+    reporter.check(namecheap.get("apply_semantics") == "whole_zone_replace", "Namecheap contract declares whole-zone replace semantics")
+    hover = contracts.get("hover", {})
+    reporter.check(hover.get("apply_semantics") == "read_only_import", "Hover contract remains read-only import")
+
+
 def validate_record_preservation(data: dict, snapshots: list[dict], reporter: Reporter) -> None:
     source = next((s for s in snapshots if s.get("id") == data.get("migration", {}).get("source_snapshot")), None)
     target = next((s for s in snapshots if s.get("id") == data.get("migration", {}).get("target_snapshot")), None)
@@ -205,6 +232,7 @@ def main(argv: list[str]) -> int:
         validate_sanitized_addresses(snapshots, reporter)
         validate_redaction(data, snapshots, reporter)
         validate_provider_coverage(snapshots, reporter)
+        validate_provider_output_contracts(data, reporter)
         validate_record_preservation(data, snapshots, reporter)
         validate_migration_safety(data, snapshots, reporter)
 


### PR DESCRIPTION
## Summary
- Extends scenario 88 with provider output contracts for Cloudflare, DigitalOcean, Namecheap, and Hover.
- Validates authority metadata, NS/MX/DNS preservation expectations, destructive-delete semantics, and provider apply semantics offline.
- Updates the scenario e2e expectations and registry test counts from 141 to 176.

## Verification
- `GOWORK=off go test ./... -count=1`
- `bash scenarios/88-iac-dns-replay-migration/test/run.sh`
- `bash scripts/test.sh 88-iac-dns-replay-migration`
- TDD proof: the new provider contract validator failed against the fixture before contract metadata was added, then passed after the fixture declared the expected contracts.