### PR TITLE
test: add hyperscaler DNS contracts

### DIFF
--- a/e2e/dns_replay_test.go
+++ b/e2e/dns_replay_test.go
@@ -25,12 +25,18 @@ func TestDNSReplayMigrationScenario(t *testing.T) {
 		"PASS: fixtures use only documentation/example IP addresses",
 		"PASS: TXT records redact verification tokens and DKIM public keys",
 		"PASS: provider coverage includes cloudflare",
+		"PASS: provider coverage includes aws",
+		"PASS: provider coverage includes azure",
+		"PASS: provider coverage includes gcp",
 		"PASS: fixture declares provider output contracts",
 		"PASS: cloudflare output contract requires authority.name_servers",
 		"PASS: namecheap output contract requires authority.is_using_our_dns",
+		"PASS: aws output contract requires records",
+		"PASS: Azure DNS contract is marked zone-authority-only",
+		"PASS: GCP Cloud DNS contract is marked zone-authority-only",
 		"PASS: MX records are preserved in target",
 		"PASS: destructive deletes require explicit opt-in",
-		"Results: 176 passed, 0 failed",
+		"Results: 228 passed, 0 failed",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("DNS replay output missing %q\n%s", want, output)

--- a/scenarios.json
+++ b/scenarios.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-24T04:35:31.745321Z",
+  "lastUpdated": "2026-05-24T04:58:25.205562Z",
   "componentVersions": {
     "workflow": "v0.2.15",
     "workflow-cloud": "v0.1.0",
@@ -1054,12 +1054,12 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "testCount": 176,
-      "passCount": 176,
+      "testCount": 228,
+      "passCount": 228,
       "failCount": 0,
       "localOnly": true,
       "notes": "Offline replay scenario for DNS/IaC import and migration safety. Validates sanitized Cloudflare, DigitalOcean, Namecheap, and Hover snapshots without provider accounts.",
-      "lastTested": "2026-05-24T04:35:31.745321Z",
+      "lastTested": "2026-05-24T04:58:25.205562Z",
       "lastResult": "pass"
     }
   }

--- a/scenarios/88-iac-dns-replay-migration/README.md
+++ b/scenarios/88-iac-dns-replay-migration/README.md
@@ -2,17 +2,18 @@
 
 Offline replay scenario for DNS/IaC import and migration safety.
 
-The scenario does not call Cloudflare, DigitalOcean, Namecheap, Hover, or any registrar API. It validates sanitized `workflow.dns-portfolio.export.v1` snapshots that model imported provider state and a planned Cloudflare target zone.
+The scenario does not call Cloudflare, DigitalOcean, Namecheap, Hover, AWS, Azure, GCP, or any registrar API. It validates sanitized `workflow.dns-portfolio.export.v1` snapshots that model imported provider state and a planned Cloudflare target zone.
 
 ## What It Tests
 
-- Provider snapshot shape for Cloudflare, DigitalOcean, Namecheap, and Hover.
+- Provider snapshot shape for Cloudflare, DigitalOcean, Namecheap, Hover, AWS Route53, Azure DNS, and GCP Cloud DNS.
 - Export metadata marking the portfolio as sanitized before it can be used as a replay fixture.
 - NS authority metadata is present for source and target zones.
 - MX, SPF, DMARC, CNAME, A, and AAAA records survive normalization.
 - Documentation/example IP ranges are used instead of public or private production addresses.
 - TXT verification tokens and DKIM material are redacted before fixture commit.
 - Cloudflare target state exposes Cloudflare nameservers.
+- Route53 target state exposes authority and record outputs; Azure DNS and GCP Cloud DNS are marked as zone-authority coverage until record-set CRUD is implemented there.
 - Destructive deletes are disabled unless explicitly opted in, and migration defaults to `plan_only`.
 - Migration plans track manual nameserver switch and MX-delivery verification steps.
 

--- a/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
+++ b/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
@@ -92,6 +92,50 @@
       ],
       "delete_unlisted_flag": "unsupported",
       "apply_semantics": "read_only_import"
+    },
+    "aws": {
+      "resource_types": [
+        "infra.dns"
+      ],
+      "dns_required_outputs": [
+        "domain",
+        "records",
+        "record_count",
+        "name_servers",
+        "authority",
+        "authority.name_servers"
+      ],
+      "delete_unlisted_flag": "unsupported",
+      "apply_semantics": "record_upsert_preserve_unlisted"
+    },
+    "azure": {
+      "resource_types": [
+        "infra.dns"
+      ],
+      "dns_required_outputs": [
+        "domain",
+        "record_count",
+        "name_servers",
+        "authority",
+        "authority.name_servers"
+      ],
+      "delete_unlisted_flag": "unsupported",
+      "apply_semantics": "zone_create_update_delete",
+      "coverage": "zone_authority_only"
+    },
+    "gcp": {
+      "resource_types": [
+        "infra.dns"
+      ],
+      "dns_required_outputs": [
+        "domain",
+        "name_servers",
+        "authority",
+        "authority.name_servers"
+      ],
+      "delete_unlisted_flag": "unsupported",
+      "apply_semantics": "zone_create_update_delete",
+      "coverage": "zone_authority_only"
     }
   },
   "snapshots": [
@@ -299,6 +343,85 @@
           "name": "_dmarc",
           "value": "v=DMARC1; p=quarantine; rua=mailto:dmarc@example.invalid",
           "ttl": 3600
+        }
+      ]
+    },
+    {
+      "id": "aws-route53-authoritative",
+      "provider": "aws",
+      "domain": "aws-route53.example",
+      "authority": {
+        "role": "target_authoritative_dns",
+        "registrar": "Route53 Domains",
+        "dns_host": "Route53",
+        "name_servers": [
+          "ns-1.awsdns-01.com",
+          "ns-2.awsdns-02.net",
+          "ns-3.awsdns-03.org",
+          "ns-4.awsdns-04.co.uk"
+        ]
+      },
+      "records": [
+        {
+          "type": "A",
+          "name": "@",
+          "value": "198.51.100.53",
+          "ttl": 300
+        },
+        {
+          "type": "MX",
+          "name": "@",
+          "value": "10 mail.aws-route53.example.",
+          "priority": 10,
+          "ttl": 300
+        }
+      ]
+    },
+    {
+      "id": "azure-dns-authority",
+      "provider": "azure",
+      "domain": "azure-dns.example",
+      "authority": {
+        "role": "target_authoritative_dns",
+        "registrar": "external",
+        "dns_host": "Azure DNS",
+        "name_servers": [
+          "ns1-01.azure-dns.com.",
+          "ns2-01.azure-dns.net.",
+          "ns3-01.azure-dns.org.",
+          "ns4-01.azure-dns.info."
+        ]
+      },
+      "records": [
+        {
+          "type": "A",
+          "name": "@",
+          "value": "203.0.113.53",
+          "ttl": 300
+        }
+      ]
+    },
+    {
+      "id": "gcp-cloud-dns-authority",
+      "provider": "gcp",
+      "domain": "gcp-cloud-dns.example",
+      "authority": {
+        "role": "target_authoritative_dns",
+        "registrar": "Cloud Domains",
+        "dns_host": "Cloud DNS",
+        "name_servers": [
+          "ns-cloud-a1.googledomains.com.",
+          "ns-cloud-a2.googledomains.com.",
+          "ns-cloud-a3.googledomains.com.",
+          "ns-cloud-a4.googledomains.com."
+        ]
+      },
+      "records": [
+        {
+          "type": "A",
+          "name": "@",
+          "value": "192.0.2.53",
+          "ttl": 300
         }
       ]
     }

--- a/scenarios/88-iac-dns-replay-migration/scenario.yaml
+++ b/scenarios/88-iac-dns-replay-migration/scenario.yaml
@@ -4,14 +4,18 @@ category: C
 description: |
   Offline replay scenario for DNS/IaC import and migration safety. Uses
   sanitized workflow.dns-portfolio.export.v1 provider snapshots for Hover,
-  DigitalOcean, Namecheap, and Cloudflare to validate record preservation,
-  redaction, and destructive-change guardrails without real provider accounts.
+  DigitalOcean, Namecheap, Cloudflare, AWS Route53, Azure DNS, and GCP Cloud
+  DNS to validate authority metadata, record preservation, redaction, and
+  destructive-change guardrails without real provider accounts.
 components:
   - workflow-scenarios replay fixture
   - iac.provider.cloudflare (target shape)
   - iac.provider.digitalocean (authoritative DNS source shape)
   - iac.provider.namecheap (registrar/DNS source shape)
   - iac.provider.hover (registrar-origin source shape)
+  - iac.provider.aws (Route53 authority and record shape)
+  - iac.provider.azure (Azure DNS authority shape)
+  - iac.provider.gcp (Cloud DNS authority shape)
   - infra.dns
 status: testable
 tags:

--- a/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
+++ b/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
@@ -146,7 +146,7 @@ def validate_redaction(data: dict, snapshots: list[dict], reporter: Reporter) ->
 
 def validate_provider_coverage(snapshots: list[dict], reporter: Reporter) -> None:
     providers = {str(snapshot.get("provider", "")).lower() for snapshot in snapshots}
-    for provider in ("cloudflare", "digitalocean", "namecheap", "hover"):
+    for provider in ("cloudflare", "digitalocean", "namecheap", "hover", "aws", "azure", "gcp"):
         reporter.check(provider in providers, f"provider coverage includes {provider}")
 
 
@@ -158,6 +158,9 @@ def validate_provider_output_contracts(data: dict, reporter: Reporter) -> None:
         "digitalocean": {"domain", "records", "record_count", "zone_file", "authority", "authority.name_servers"},
         "namecheap": {"domain", "record_count", "authority", "authority.is_using_our_dns", "authority.email_type"},
         "hover": {"domain", "records", "record_count", "authority", "authority.name_servers"},
+        "aws": {"domain", "records", "record_count", "authority", "authority.name_servers"},
+        "azure": {"domain", "record_count", "authority", "authority.name_servers"},
+        "gcp": {"domain", "authority", "authority.name_servers"},
     }
     for provider, required_paths in required.items():
         contract = contracts.get(provider, {})
@@ -175,6 +178,12 @@ def validate_provider_output_contracts(data: dict, reporter: Reporter) -> None:
     reporter.check(namecheap.get("apply_semantics") == "whole_zone_replace", "Namecheap contract declares whole-zone replace semantics")
     hover = contracts.get("hover", {})
     reporter.check(hover.get("apply_semantics") == "read_only_import", "Hover contract remains read-only import")
+    aws = contracts.get("aws", {})
+    reporter.check(aws.get("apply_semantics") == "record_upsert_preserve_unlisted", "AWS Route53 contract declares record upsert semantics")
+    azure = contracts.get("azure", {})
+    reporter.check(azure.get("coverage") == "zone_authority_only", "Azure DNS contract is marked zone-authority-only")
+    gcp = contracts.get("gcp", {})
+    reporter.check(gcp.get("coverage") == "zone_authority_only", "GCP Cloud DNS contract is marked zone-authority-only")
 
 
 def validate_record_preservation(data: dict, snapshots: list[dict], reporter: Reporter) -> None:


### PR DESCRIPTION
## Summary
- Extends scenario 88 with AWS Route53, Azure DNS, and GCP Cloud DNS provider coverage.
- Declares output contracts for Route53 record import and Azure/GCP zone-authority coverage.
- Updates replay docs, e2e assertions, and scenario registry count from 176 to 228.

## Verification
- `python3 -m json.tool scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json >/tmp/dns-portfolio-hyperscaler.json`
- `python3 -c "import yaml; yaml.safe_load(open('scenarios/88-iac-dns-replay-migration/scenario.yaml'))"`\n- `bash scenarios/88-iac-dns-replay-migration/test/run.sh`\n- `GOWORK=off go test ./... -count=1`\n- `bash scripts/test.sh 88-iac-dns-replay-migration`\n- TDD proof: the validator failed with 21 missing-provider/contract failures before the fixture and docs were updated, then passed at 228/228.