### PR TITLE
test: require Azure and GCP DNS record contracts

### DIFF
--- a/e2e/dns_replay_test.go
+++ b/e2e/dns_replay_test.go
@@ -32,11 +32,11 @@ func TestDNSReplayMigrationScenario(t *testing.T) {
 		"PASS: cloudflare output contract requires authority.name_servers",
 		"PASS: namecheap output contract requires authority.is_using_our_dns",
 		"PASS: aws output contract requires records",
-		"PASS: Azure DNS contract is marked zone-authority-only",
-		"PASS: GCP Cloud DNS contract is marked zone-authority-only",
+		"PASS: Azure DNS contract declares record upsert semantics",
+		"PASS: GCP Cloud DNS contract declares record upsert semantics",
 		"PASS: MX records are preserved in target",
 		"PASS: destructive deletes require explicit opt-in",
-		"Results: 228 passed, 0 failed",
+		"Results: 231 passed, 0 failed",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("DNS replay output missing %q\n%s", want, output)

--- a/scenarios.json
+++ b/scenarios.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-24T04:58:25.205562Z",
+  "lastUpdated": "2026-05-24T05:24:40.042516Z",
   "componentVersions": {
     "workflow": "v0.2.15",
     "workflow-cloud": "v0.1.0",
@@ -1054,12 +1054,12 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "testCount": 228,
-      "passCount": 228,
+      "testCount": 231,
+      "passCount": 231,
       "failCount": 0,
       "localOnly": true,
-      "notes": "Offline replay scenario for DNS/IaC import and migration safety. Validates sanitized Cloudflare, DigitalOcean, Namecheap, and Hover snapshots without provider accounts.",
-      "lastTested": "2026-05-24T04:58:25.205562Z",
+      "notes": "Offline replay scenario for DNS/IaC import and migration safety. Validates sanitized Cloudflare, DigitalOcean, Namecheap, Hover, AWS, Azure, and GCP snapshots without provider accounts.",
+      "lastTested": "2026-05-24T05:24:40.042516Z",
       "lastResult": "pass"
     }
   }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-24T05:24:40.042516Z",
+  "lastUpdated": "2026-05-24T05:25:28.301346Z",
   "componentVersions": {
     "workflow": "v0.2.15",
     "workflow-cloud": "v0.1.0",
@@ -1059,7 +1059,7 @@
       "failCount": 0,
       "localOnly": true,
       "notes": "Offline replay scenario for DNS/IaC import and migration safety. Validates sanitized Cloudflare, DigitalOcean, Namecheap, Hover, AWS, Azure, and GCP snapshots without provider accounts.",
-      "lastTested": "2026-05-24T05:24:40.042516Z",
+      "lastTested": "2026-05-24T05:25:28.301346Z",
       "lastResult": "pass"
     }
   }

--- a/scenarios/88-iac-dns-replay-migration/README.md
+++ b/scenarios/88-iac-dns-replay-migration/README.md
@@ -13,7 +13,7 @@ The scenario does not call Cloudflare, DigitalOcean, Namecheap, Hover, AWS, Azur
 - Documentation/example IP ranges are used instead of public or private production addresses.
 - TXT verification tokens and DKIM material are redacted before fixture commit.
 - Cloudflare target state exposes Cloudflare nameservers.
-- Route53 target state exposes authority and record outputs; Azure DNS and GCP Cloud DNS are marked as zone-authority coverage until record-set CRUD is implemented there.
+- Route53, Azure DNS, and GCP Cloud DNS target states expose authority and record outputs with non-destructive record upsert semantics.
 - Destructive deletes are disabled unless explicitly opted in, and migration defaults to `plan_only`.
 - Migration plans track manual nameserver switch and MX-delivery verification steps.
 

--- a/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
+++ b/scenarios/88-iac-dns-replay-migration/fixtures/dns-portfolio.json
@@ -114,14 +114,14 @@
       ],
       "dns_required_outputs": [
         "domain",
+        "records",
         "record_count",
         "name_servers",
         "authority",
         "authority.name_servers"
       ],
       "delete_unlisted_flag": "unsupported",
-      "apply_semantics": "zone_create_update_delete",
-      "coverage": "zone_authority_only"
+      "apply_semantics": "record_upsert_preserve_unlisted"
     },
     "gcp": {
       "resource_types": [
@@ -129,13 +129,14 @@
       ],
       "dns_required_outputs": [
         "domain",
+        "records",
+        "record_count",
         "name_servers",
         "authority",
         "authority.name_servers"
       ],
       "delete_unlisted_flag": "unsupported",
-      "apply_semantics": "zone_create_update_delete",
-      "coverage": "zone_authority_only"
+      "apply_semantics": "record_upsert_preserve_unlisted"
     }
   },
   "snapshots": [

--- a/scenarios/88-iac-dns-replay-migration/scenario.yaml
+++ b/scenarios/88-iac-dns-replay-migration/scenario.yaml
@@ -14,8 +14,8 @@ components:
   - iac.provider.namecheap (registrar/DNS source shape)
   - iac.provider.hover (registrar-origin source shape)
   - iac.provider.aws (Route53 authority and record shape)
-  - iac.provider.azure (Azure DNS authority shape)
-  - iac.provider.gcp (Cloud DNS authority shape)
+  - iac.provider.azure (Azure DNS authority and record shape)
+  - iac.provider.gcp (Cloud DNS authority and record shape)
   - infra.dns
 status: testable
 tags:

--- a/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
+++ b/scenarios/88-iac-dns-replay-migration/test/validate_dns_replay.py
@@ -159,8 +159,8 @@ def validate_provider_output_contracts(data: dict, reporter: Reporter) -> None:
         "namecheap": {"domain", "record_count", "authority", "authority.is_using_our_dns", "authority.email_type"},
         "hover": {"domain", "records", "record_count", "authority", "authority.name_servers"},
         "aws": {"domain", "records", "record_count", "authority", "authority.name_servers"},
-        "azure": {"domain", "record_count", "authority", "authority.name_servers"},
-        "gcp": {"domain", "authority", "authority.name_servers"},
+        "azure": {"domain", "records", "record_count", "authority", "authority.name_servers"},
+        "gcp": {"domain", "records", "record_count", "authority", "authority.name_servers"},
     }
     for provider, required_paths in required.items():
         contract = contracts.get(provider, {})
@@ -181,9 +181,9 @@ def validate_provider_output_contracts(data: dict, reporter: Reporter) -> None:
     aws = contracts.get("aws", {})
     reporter.check(aws.get("apply_semantics") == "record_upsert_preserve_unlisted", "AWS Route53 contract declares record upsert semantics")
     azure = contracts.get("azure", {})
-    reporter.check(azure.get("coverage") == "zone_authority_only", "Azure DNS contract is marked zone-authority-only")
+    reporter.check(azure.get("apply_semantics") == "record_upsert_preserve_unlisted", "Azure DNS contract declares record upsert semantics")
     gcp = contracts.get("gcp", {})
-    reporter.check(gcp.get("coverage") == "zone_authority_only", "GCP Cloud DNS contract is marked zone-authority-only")
+    reporter.check(gcp.get("apply_semantics") == "record_upsert_preserve_unlisted", "GCP Cloud DNS contract declares record upsert semantics")
 
 
 def validate_record_preservation(data: dict, snapshots: list[dict], reporter: Reporter) -> None:


### PR DESCRIPTION
## Summary
- promote Azure DNS and GCP Cloud DNS scenario contracts from zone-authority-only to record output coverage
- require non-destructive record_upsert_preserve_unlisted semantics for both providers
- update DNS replay expectations from 228 to 231 checks

## Verification
- RED before fixture update: validator reported 5 failures for missing Azure/GCP records and semantics
- 
- 
- 
=== Scenario 88-iac-dns-replay-migration ===

PASS: fixture is valid JSON
PASS: fixture declares export schema v1
PASS: fixture is explicitly marked sanitized
PASS: fixture includes generation timestamp
PASS: fixture includes non-sensitive source portfolio id
PASS: sanitization status is sanitized
PASS: sanitization rule records domain_aliases
PASS: sanitization rule records example_ip_addresses
PASS: sanitization rule records txt_secret_redaction
PASS: sanitization rule records email_redaction
PASS: sanitization declares forbidden patterns
PASS: fixture declares at least four provider snapshots
PASS: hover-source declares provider
PASS: hover-source declares domain
PASS: hover-source declares authority metadata
PASS: hover-source declares records
PASS: hover-source record 0 has type
PASS: hover-source record 0 has name
PASS: hover-source record 0 has value
PASS: hover-source record 0 has positive ttl
PASS: hover-source record 1 has type
PASS: hover-source record 1 has name
PASS: hover-source record 1 has value
PASS: hover-source record 1 has positive ttl
PASS: hover-source record 2 has type
PASS: hover-source record 2 has name
PASS: hover-source record 2 has value
PASS: hover-source record 2 has positive ttl
PASS: hover-source record 3 has type
PASS: hover-source record 3 has name
PASS: hover-source record 3 has value
PASS: hover-source record 3 has positive ttl
PASS: hover-source record 4 has type
PASS: hover-source record 4 has name
PASS: hover-source record 4 has value
PASS: hover-source record 4 has positive ttl
PASS: hover-source record 5 has type
PASS: hover-source record 5 has name
PASS: hover-source record 5 has value
PASS: hover-source record 5 has positive ttl
PASS: hover-source record 6 has type
PASS: hover-source record 6 has name
PASS: hover-source record 6 has value
PASS: hover-source record 6 has positive ttl
PASS: digitalocean-authoritative declares provider
PASS: digitalocean-authoritative declares domain
PASS: digitalocean-authoritative declares authority metadata
PASS: digitalocean-authoritative declares records
PASS: digitalocean-authoritative record 0 has type
PASS: digitalocean-authoritative record 0 has name
PASS: digitalocean-authoritative record 0 has value
PASS: digitalocean-authoritative record 0 has positive ttl
PASS: digitalocean-authoritative record 1 has type
PASS: digitalocean-authoritative record 1 has name
PASS: digitalocean-authoritative record 1 has value
PASS: digitalocean-authoritative record 1 has positive ttl
PASS: digitalocean-authoritative record 2 has type
PASS: digitalocean-authoritative record 2 has name
PASS: digitalocean-authoritative record 2 has value
PASS: digitalocean-authoritative record 2 has positive ttl
PASS: digitalocean-authoritative record 3 has type
PASS: digitalocean-authoritative record 3 has name
PASS: digitalocean-authoritative record 3 has value
PASS: digitalocean-authoritative record 3 has positive ttl
PASS: namecheap-managed declares provider
PASS: namecheap-managed declares domain
PASS: namecheap-managed declares authority metadata
PASS: namecheap-managed declares records
PASS: namecheap-managed record 0 has type
PASS: namecheap-managed record 0 has name
PASS: namecheap-managed record 0 has value
PASS: namecheap-managed record 0 has positive ttl
PASS: namecheap-managed record 1 has type
PASS: namecheap-managed record 1 has name
PASS: namecheap-managed record 1 has value
PASS: namecheap-managed record 1 has positive ttl
PASS: namecheap-managed record 2 has type
PASS: namecheap-managed record 2 has name
PASS: namecheap-managed record 2 has value
PASS: namecheap-managed record 2 has positive ttl
PASS: cloudflare-target declares provider
PASS: cloudflare-target declares domain
PASS: cloudflare-target declares authority metadata
PASS: cloudflare-target declares records
PASS: cloudflare-target record 0 has type
PASS: cloudflare-target record 0 has name
PASS: cloudflare-target record 0 has value
PASS: cloudflare-target record 0 has positive ttl
PASS: cloudflare-target record 1 has type
PASS: cloudflare-target record 1 has name
PASS: cloudflare-target record 1 has value
PASS: cloudflare-target record 1 has positive ttl
PASS: cloudflare-target record 2 has type
PASS: cloudflare-target record 2 has name
PASS: cloudflare-target record 2 has value
PASS: cloudflare-target record 2 has positive ttl
PASS: cloudflare-target record 3 has type
PASS: cloudflare-target record 3 has name
PASS: cloudflare-target record 3 has value
PASS: cloudflare-target record 3 has positive ttl
PASS: cloudflare-target record 4 has type
PASS: cloudflare-target record 4 has name
PASS: cloudflare-target record 4 has value
PASS: cloudflare-target record 4 has positive ttl
PASS: cloudflare-target record 5 has type
PASS: cloudflare-target record 5 has name
PASS: cloudflare-target record 5 has value
PASS: cloudflare-target record 5 has positive ttl
PASS: cloudflare-target record 6 has type
PASS: cloudflare-target record 6 has name
PASS: cloudflare-target record 6 has value
PASS: cloudflare-target record 6 has positive ttl
PASS: aws-route53-authoritative declares provider
PASS: aws-route53-authoritative declares domain
PASS: aws-route53-authoritative declares authority metadata
PASS: aws-route53-authoritative declares records
PASS: aws-route53-authoritative record 0 has type
PASS: aws-route53-authoritative record 0 has name
PASS: aws-route53-authoritative record 0 has value
PASS: aws-route53-authoritative record 0 has positive ttl
PASS: aws-route53-authoritative record 1 has type
PASS: aws-route53-authoritative record 1 has name
PASS: aws-route53-authoritative record 1 has value
PASS: aws-route53-authoritative record 1 has positive ttl
PASS: azure-dns-authority declares provider
PASS: azure-dns-authority declares domain
PASS: azure-dns-authority declares authority metadata
PASS: azure-dns-authority declares records
PASS: azure-dns-authority record 0 has type
PASS: azure-dns-authority record 0 has name
PASS: azure-dns-authority record 0 has value
PASS: azure-dns-authority record 0 has positive ttl
PASS: gcp-cloud-dns-authority declares provider
PASS: gcp-cloud-dns-authority declares domain
PASS: gcp-cloud-dns-authority declares authority metadata
PASS: gcp-cloud-dns-authority declares records
PASS: gcp-cloud-dns-authority record 0 has type
PASS: gcp-cloud-dns-authority record 0 has name
PASS: gcp-cloud-dns-authority record 0 has value
PASS: gcp-cloud-dns-authority record 0 has positive ttl
PASS: fixtures use only documentation/example IP addresses
PASS: fixture excludes forbidden pattern hover-source.test
PASS: fixture excludes forbidden pattern do-authoritative.test
PASS: fixture excludes forbidden pattern namecheap-managed.test
PASS: fixture excludes forbidden pattern cloudflare-target.test
PASS: fixture excludes forbidden pattern google-site-verification=
PASS: fixture excludes forbidden pattern keybase-site-verification=
PASS: TXT records redact verification tokens and DKIM public keys
PASS: provider coverage includes cloudflare
PASS: provider coverage includes digitalocean
PASS: provider coverage includes namecheap
PASS: provider coverage includes hover
PASS: provider coverage includes aws
PASS: provider coverage includes azure
PASS: provider coverage includes gcp
PASS: fixture declares provider output contracts
PASS: cloudflare output contract is an object
PASS: cloudflare output contract covers infra.dns
PASS: cloudflare output contract requires authority
PASS: cloudflare output contract requires authority.name_servers
PASS: cloudflare output contract requires authority.original_name_servers
PASS: cloudflare output contract requires domain
PASS: cloudflare output contract requires record_count
PASS: cloudflare output contract requires records
PASS: digitalocean output contract is an object
PASS: digitalocean output contract covers infra.dns
PASS: digitalocean output contract requires authority
PASS: digitalocean output contract requires authority.name_servers
PASS: digitalocean output contract requires domain
PASS: digitalocean output contract requires record_count
PASS: digitalocean output contract requires records
PASS: digitalocean output contract requires zone_file
PASS: namecheap output contract is an object
PASS: namecheap output contract covers infra.dns
PASS: namecheap output contract requires authority
PASS: namecheap output contract requires authority.email_type
PASS: namecheap output contract requires authority.is_using_our_dns
PASS: namecheap output contract requires domain
PASS: namecheap output contract requires record_count
PASS: hover output contract is an object
PASS: hover output contract covers infra.dns
PASS: hover output contract requires authority
PASS: hover output contract requires authority.name_servers
PASS: hover output contract requires domain
PASS: hover output contract requires record_count
PASS: hover output contract requires records
PASS: aws output contract is an object
PASS: aws output contract covers infra.dns
PASS: aws output contract requires authority
PASS: aws output contract requires authority.name_servers
PASS: aws output contract requires domain
PASS: aws output contract requires record_count
PASS: aws output contract requires records
PASS: azure output contract is an object
PASS: azure output contract covers infra.dns
PASS: azure output contract requires authority
PASS: azure output contract requires authority.name_servers
PASS: azure output contract requires domain
PASS: azure output contract requires record_count
PASS: azure output contract requires records
PASS: gcp output contract is an object
PASS: gcp output contract covers infra.dns
PASS: gcp output contract requires authority
PASS: gcp output contract requires authority.name_servers
PASS: gcp output contract requires domain
PASS: gcp output contract requires record_count
PASS: gcp output contract requires records
PASS: Cloudflare contract requires explicit manage_unlisted for destructive reconciliation
PASS: DigitalOcean contract does not delete undeclared DNS records
PASS: Namecheap contract declares whole-zone replace semantics
PASS: Hover contract remains read-only import
PASS: AWS Route53 contract declares record upsert semantics
PASS: Azure DNS contract declares record upsert semantics
PASS: GCP Cloud DNS contract declares record upsert semantics
PASS: migration source and target snapshots resolve
PASS: source includes MX records
PASS: source includes TXT records
PASS: source includes CNAME records
PASS: source includes A records
PASS: target includes migrated MX records
PASS: target includes migrated TXT records
PASS: target includes migrated CNAME records
PASS: target includes migrated A records
PASS: MX records are preserved in target
PASS: source includes SPF TXT
PASS: source includes DMARC TXT
PASS: destructive deletes require explicit opt-in
PASS: migration defaults to plan-only apply mode
PASS: target exposes Cloudflare nameservers
PASS: migration tracks registrar nameserver switch
PASS: migration tracks MX delivery verification

Results: 231 passed, 0 failed
- ?   	github.com/GoCodeAlone/workflow-scenarios/cmd/sample-orders	[no test files]
ok  	github.com/GoCodeAlone/workflow-scenarios/e2e	0.891s
?   	github.com/GoCodeAlone/workflow-scenarios/samples/orders	[no test files]
?   	github.com/GoCodeAlone/workflow-scenarios/scenarios/56-launchdarkly-integration/mock	[no test files]
- Testing scenario: 88-iac-dns-replay-migration in namespace: local
================================================
bash: warning: setlocale: LC_ALL: cannot change locale (C.UTF-8): No such file or directory

=== Scenario 88-iac-dns-replay-migration ===

PASS: fixture is valid JSON
PASS: fixture declares export schema v1
PASS: fixture is explicitly marked sanitized
PASS: fixture includes generation timestamp
PASS: fixture includes non-sensitive source portfolio id
PASS: sanitization status is sanitized
PASS: sanitization rule records domain_aliases
PASS: sanitization rule records example_ip_addresses
PASS: sanitization rule records txt_secret_redaction
PASS: sanitization rule records email_redaction
PASS: sanitization declares forbidden patterns
PASS: fixture declares at least four provider snapshots
PASS: hover-source declares provider
PASS: hover-source declares domain
PASS: hover-source declares authority metadata
PASS: hover-source declares records
PASS: hover-source record 0 has type
PASS: hover-source record 0 has name
PASS: hover-source record 0 has value
PASS: hover-source record 0 has positive ttl
PASS: hover-source record 1 has type
PASS: hover-source record 1 has name
PASS: hover-source record 1 has value
PASS: hover-source record 1 has positive ttl
PASS: hover-source record 2 has type
PASS: hover-source record 2 has name
PASS: hover-source record 2 has value
PASS: hover-source record 2 has positive ttl
PASS: hover-source record 3 has type
PASS: hover-source record 3 has name
PASS: hover-source record 3 has value
PASS: hover-source record 3 has positive ttl
PASS: hover-source record 4 has type
PASS: hover-source record 4 has name
PASS: hover-source record 4 has value
PASS: hover-source record 4 has positive ttl
PASS: hover-source record 5 has type
PASS: hover-source record 5 has name
PASS: hover-source record 5 has value
PASS: hover-source record 5 has positive ttl
PASS: hover-source record 6 has type
PASS: hover-source record 6 has name
PASS: hover-source record 6 has value
PASS: hover-source record 6 has positive ttl
PASS: digitalocean-authoritative declares provider
PASS: digitalocean-authoritative declares domain
PASS: digitalocean-authoritative declares authority metadata
PASS: digitalocean-authoritative declares records
PASS: digitalocean-authoritative record 0 has type
PASS: digitalocean-authoritative record 0 has name
PASS: digitalocean-authoritative record 0 has value
PASS: digitalocean-authoritative record 0 has positive ttl
PASS: digitalocean-authoritative record 1 has type
PASS: digitalocean-authoritative record 1 has name
PASS: digitalocean-authoritative record 1 has value
PASS: digitalocean-authoritative record 1 has positive ttl
PASS: digitalocean-authoritative record 2 has type
PASS: digitalocean-authoritative record 2 has name
PASS: digitalocean-authoritative record 2 has value
PASS: digitalocean-authoritative record 2 has positive ttl
PASS: digitalocean-authoritative record 3 has type
PASS: digitalocean-authoritative record 3 has name
PASS: digitalocean-authoritative record 3 has value
PASS: digitalocean-authoritative record 3 has positive ttl
PASS: namecheap-managed declares provider
PASS: namecheap-managed declares domain
PASS: namecheap-managed declares authority metadata
PASS: namecheap-managed declares records
PASS: namecheap-managed record 0 has type
PASS: namecheap-managed record 0 has name
PASS: namecheap-managed record 0 has value
PASS: namecheap-managed record 0 has positive ttl
PASS: namecheap-managed record 1 has type
PASS: namecheap-managed record 1 has name
PASS: namecheap-managed record 1 has value
PASS: namecheap-managed record 1 has positive ttl
PASS: namecheap-managed record 2 has type
PASS: namecheap-managed record 2 has name
PASS: namecheap-managed record 2 has value
PASS: namecheap-managed record 2 has positive ttl
PASS: cloudflare-target declares provider
PASS: cloudflare-target declares domain
PASS: cloudflare-target declares authority metadata
PASS: cloudflare-target declares records
PASS: cloudflare-target record 0 has type
PASS: cloudflare-target record 0 has name
PASS: cloudflare-target record 0 has value
PASS: cloudflare-target record 0 has positive ttl
PASS: cloudflare-target record 1 has type
PASS: cloudflare-target record 1 has name
PASS: cloudflare-target record 1 has value
PASS: cloudflare-target record 1 has positive ttl
PASS: cloudflare-target record 2 has type
PASS: cloudflare-target record 2 has name
PASS: cloudflare-target record 2 has value
PASS: cloudflare-target record 2 has positive ttl
PASS: cloudflare-target record 3 has type
PASS: cloudflare-target record 3 has name
PASS: cloudflare-target record 3 has value
PASS: cloudflare-target record 3 has positive ttl
PASS: cloudflare-target record 4 has type
PASS: cloudflare-target record 4 has name
PASS: cloudflare-target record 4 has value
PASS: cloudflare-target record 4 has positive ttl
PASS: cloudflare-target record 5 has type
PASS: cloudflare-target record 5 has name
PASS: cloudflare-target record 5 has value
PASS: cloudflare-target record 5 has positive ttl
PASS: cloudflare-target record 6 has type
PASS: cloudflare-target record 6 has name
PASS: cloudflare-target record 6 has value
PASS: cloudflare-target record 6 has positive ttl
PASS: aws-route53-authoritative declares provider
PASS: aws-route53-authoritative declares domain
PASS: aws-route53-authoritative declares authority metadata
PASS: aws-route53-authoritative declares records
PASS: aws-route53-authoritative record 0 has type
PASS: aws-route53-authoritative record 0 has name
PASS: aws-route53-authoritative record 0 has value
PASS: aws-route53-authoritative record 0 has positive ttl
PASS: aws-route53-authoritative record 1 has type
PASS: aws-route53-authoritative record 1 has name
PASS: aws-route53-authoritative record 1 has value
PASS: aws-route53-authoritative record 1 has positive ttl
PASS: azure-dns-authority declares provider
PASS: azure-dns-authority declares domain
PASS: azure-dns-authority declares authority metadata
PASS: azure-dns-authority declares records
PASS: azure-dns-authority record 0 has type
PASS: azure-dns-authority record 0 has name
PASS: azure-dns-authority record 0 has value
PASS: azure-dns-authority record 0 has positive ttl
PASS: gcp-cloud-dns-authority declares provider
PASS: gcp-cloud-dns-authority declares domain
PASS: gcp-cloud-dns-authority declares authority metadata
PASS: gcp-cloud-dns-authority declares records
PASS: gcp-cloud-dns-authority record 0 has type
PASS: gcp-cloud-dns-authority record 0 has name
PASS: gcp-cloud-dns-authority record 0 has value
PASS: gcp-cloud-dns-authority record 0 has positive ttl
PASS: fixtures use only documentation/example IP addresses
PASS: fixture excludes forbidden pattern hover-source.test
PASS: fixture excludes forbidden pattern do-authoritative.test
PASS: fixture excludes forbidden pattern namecheap-managed.test
PASS: fixture excludes forbidden pattern cloudflare-target.test
PASS: fixture excludes forbidden pattern google-site-verification=
PASS: fixture excludes forbidden pattern keybase-site-verification=
PASS: TXT records redact verification tokens and DKIM public keys
PASS: provider coverage includes cloudflare
PASS: provider coverage includes digitalocean
PASS: provider coverage includes namecheap
PASS: provider coverage includes hover
PASS: provider coverage includes aws
PASS: provider coverage includes azure
PASS: provider coverage includes gcp
PASS: fixture declares provider output contracts
PASS: cloudflare output contract is an object
PASS: cloudflare output contract covers infra.dns
PASS: cloudflare output contract requires authority
PASS: cloudflare output contract requires authority.name_servers
PASS: cloudflare output contract requires authority.original_name_servers
PASS: cloudflare output contract requires domain
PASS: cloudflare output contract requires record_count
PASS: cloudflare output contract requires records
PASS: digitalocean output contract is an object
PASS: digitalocean output contract covers infra.dns
PASS: digitalocean output contract requires authority
PASS: digitalocean output contract requires authority.name_servers
PASS: digitalocean output contract requires domain
PASS: digitalocean output contract requires record_count
PASS: digitalocean output contract requires records
PASS: digitalocean output contract requires zone_file
PASS: namecheap output contract is an object
PASS: namecheap output contract covers infra.dns
PASS: namecheap output contract requires authority
PASS: namecheap output contract requires authority.email_type
PASS: namecheap output contract requires authority.is_using_our_dns
PASS: namecheap output contract requires domain
PASS: namecheap output contract requires record_count
PASS: hover output contract is an object
PASS: hover output contract covers infra.dns
PASS: hover output contract requires authority
PASS: hover output contract requires authority.name_servers
PASS: hover output contract requires domain
PASS: hover output contract requires record_count
PASS: hover output contract requires records
PASS: aws output contract is an object
PASS: aws output contract covers infra.dns
PASS: aws output contract requires authority
PASS: aws output contract requires authority.name_servers
PASS: aws output contract requires domain
PASS: aws output contract requires record_count
PASS: aws output contract requires records
PASS: azure output contract is an object
PASS: azure output contract covers infra.dns
PASS: azure output contract requires authority
PASS: azure output contract requires authority.name_servers
PASS: azure output contract requires domain
PASS: azure output contract requires record_count
PASS: azure output contract requires records
PASS: gcp output contract is an object
PASS: gcp output contract covers infra.dns
PASS: gcp output contract requires authority
PASS: gcp output contract requires authority.name_servers
PASS: gcp output contract requires domain
PASS: gcp output contract requires record_count
PASS: gcp output contract requires records
PASS: Cloudflare contract requires explicit manage_unlisted for destructive reconciliation
PASS: DigitalOcean contract does not delete undeclared DNS records
PASS: Namecheap contract declares whole-zone replace semantics
PASS: Hover contract remains read-only import
PASS: AWS Route53 contract declares record upsert semantics
PASS: Azure DNS contract declares record upsert semantics
PASS: GCP Cloud DNS contract declares record upsert semantics
PASS: migration source and target snapshots resolve
PASS: source includes MX records
PASS: source includes TXT records
PASS: source includes CNAME records
PASS: source includes A records
PASS: target includes migrated MX records
PASS: target includes migrated TXT records
PASS: target includes migrated CNAME records
PASS: target includes migrated A records
PASS: MX records are preserved in target
PASS: source includes SPF TXT
PASS: source includes DMARC TXT
PASS: destructive deletes require explicit opt-in
PASS: migration defaults to plan-only apply mode
PASS: target exposes Cloudflare nameservers
PASS: migration tracks registrar nameserver switch
PASS: migration tracks MX delivery verification

Results: 231 passed, 0 failed

RESULT: ALL TESTS PASSED (231/231)