### PR TITLE
feat: add dynamic admin provider scenario

### DIFF
--- a/scenarios.json
+++ b/scenarios.json
@@ -1086,6 +1086,18 @@
       "lastTested": null,
       "lastResult": null
     },
+    "90-admin-tailnet-demo": {
+      "status": "testable",
+      "namespace": "local",
+      "deployed": false,
+      "testCount": 0,
+      "passCount": 0,
+      "failCount": 0,
+      "localOnly": true,
+      "notes": "Docker Compose app/admin demo with auth-gated admin portal, dynamic auth provider descriptor catalog, authz RBAC/ABAC/ReBAC UI, Ory Keto enforcement, and optional Tailscale sidecar.",
+      "lastTested": null,
+      "lastResult": null
+    },
     "91-dns-delegation": {
       "status": "draft",
       "namespace": "local",

--- a/scenarios/90-admin-tailnet-demo/README.md
+++ b/scenarios/90-admin-tailnet-demo/README.md
@@ -5,13 +5,28 @@ This scenario runs a small app with an auth-gated administration portal, a decla
 - App: <http://localhost:18080/>
 - Admin: <http://localhost:18080/admin>
 - Authz admin contribution: <http://localhost:18080/admin/authz>
+- Auth provider catalog API: <http://localhost:18080/api/admin/auth/providers>
 - Status API: <http://localhost:18080/api/status>
 
 Demo users:
 
 - `admin@tailnet` / `admin`: full admin and frontend scopes.
+- `provider-admin@tailnet` / `provider`: auth provider read-only admin.
 - `readonly-admin@tailnet` / `readonly`: admin read scopes only.
 - `app-user@tailnet` / `user`: frontend scopes only.
+
+The auth provider catalog composes descriptor-shaped records for released
+Workflow provider plugins:
+
+- `workflow-plugin-auth v0.2.11`
+- `workflow-plugin-sso v0.1.6`
+- `workflow-plugin-okta v0.2.4`
+- `workflow-plugin-auth0 v0.1.0`
+- `workflow-plugin-entra v0.1.0`
+- `workflow-plugin-ory-kratos v0.1.0`
+- `workflow-plugin-ory-hydra v0.1.0`
+- `workflow-plugin-ory-polis v0.1.0`
+- `workflow-plugin-scalekit v0.1.0`
 
 The authz contribution displays frontend and admin scopes from the declared scope catalog, including owner plugin/module metadata. The demo defaults to `AUTHZ_PROVIDER=keto`, runs a local Ory Keto container, and resolves role assignments into Keto scope relationship checks for the app/admin surfaces.
 

--- a/scenarios/90-admin-tailnet-demo/app/app.py
+++ b/scenarios/90-admin-tailnet-demo/app/app.py
@@ -28,6 +28,10 @@ users = {
         "password": "readonly",
         "scopes": ["admin:dashboard:read", "admin:authz.roles:read", "admin:authz.scopes:read"],
     },
+    "provider-admin@tailnet": {
+        "password": "provider",
+        "scopes": ["admin:dashboard:read", "admin:auth.settings:read", "admin:auth.providers:read"],
+    },
     "admin@tailnet": {
         "password": "admin",
         "scopes": [
@@ -37,6 +41,8 @@ users = {
             "admin:app:update",
             "admin:auth.settings:read",
             "admin:auth.settings:update",
+            "admin:auth.providers:read",
+            "admin:auth.providers:update",
             "admin:authz.roles:read",
             "admin:authz.roles:update",
             "admin:authz.scopes:read",
@@ -58,6 +64,8 @@ state = {
         {"name": "admin:app:update", "context": "admin", "resource": "app", "actions": ["update"], "description": "Update application operations from admin", "owner_plugin": "workflow-plugin-admin", "owner_module": "admin", "category": "admin"},
         {"name": "admin:auth.settings:read", "context": "admin", "resource": "auth.settings", "actions": ["read"], "description": "Inspect authentication plugin settings", "owner_plugin": "workflow-plugin-auth", "owner_module": "admin-config", "category": "security"},
         {"name": "admin:auth.settings:update", "context": "admin", "resource": "auth.settings", "actions": ["update"], "description": "Validate and update authentication plugin settings", "owner_plugin": "workflow-plugin-auth", "owner_module": "admin-config", "category": "security"},
+        {"name": "admin:auth.providers:read", "context": "admin", "resource": "auth.providers", "actions": ["read"], "description": "Inspect registered authentication provider descriptors", "owner_plugin": "workflow-plugin-auth", "owner_module": "provider-catalog", "category": "security"},
+        {"name": "admin:auth.providers:update", "context": "admin", "resource": "auth.providers", "actions": ["update"], "description": "Update authentication provider configuration", "owner_plugin": "workflow-plugin-auth", "owner_module": "provider-catalog", "category": "security"},
         {"name": "admin:authz.roles:read", "context": "admin", "resource": "authz.roles", "actions": ["read"], "description": "Inspect role assignments", "owner_plugin": "workflow-plugin-authz", "owner_module": "scope-catalog", "category": "security"},
         {"name": "admin:authz.roles:update", "context": "admin", "resource": "authz.roles", "actions": ["update"], "description": "Create and remove role assignments", "owner_plugin": "workflow-plugin-authz", "owner_module": "scope-catalog", "category": "security"},
         {"name": "admin:authz.scopes:read", "context": "admin", "resource": "authz.scopes", "actions": ["read"], "description": "Inspect declared application scopes", "owner_plugin": "workflow-plugin-authz", "owner_module": "scope-catalog", "category": "security"},
@@ -69,7 +77,8 @@ state = {
     "roles": [
         {"user": "app-user@tailnet", "role": "requester", "context": "frontend", "scopes": ["frontend:orders:read", "frontend:requests:create"]},
         {"user": "readonly-admin@tailnet", "role": "authz-viewer", "context": "admin", "scopes": ["admin:dashboard:read", "admin:authz.roles:read", "admin:authz.scopes:read"]},
-        {"user": "admin@tailnet", "role": "authz-admin", "context": "admin", "scopes": ["admin:dashboard:read", "admin:app:update", "admin:auth.settings:read", "admin:auth.settings:update", "admin:authz.roles:read", "admin:authz.roles:update", "admin:authz.scopes:read", "admin:authz.policies:read", "admin:authz.policies:update", "admin:authz.relations:read", "admin:authz.relations:update"]},
+        {"user": "provider-admin@tailnet", "role": "auth-provider-viewer", "context": "admin", "scopes": ["admin:dashboard:read", "admin:auth.settings:read", "admin:auth.providers:read"]},
+        {"user": "admin@tailnet", "role": "authz-admin", "context": "admin", "scopes": ["admin:dashboard:read", "admin:app:update", "admin:auth.settings:read", "admin:auth.settings:update", "admin:auth.providers:read", "admin:auth.providers:update", "admin:authz.roles:read", "admin:authz.roles:update", "admin:authz.scopes:read", "admin:authz.policies:read", "admin:authz.policies:update", "admin:authz.relations:read", "admin:authz.relations:update"]},
     ],
     "auth_config": {
         "environment": "development",
@@ -84,6 +93,15 @@ state = {
         "google_oauth_redirect_url": "https://tailnet-demo.local/auth/google/callback",
         "totp_auth_enabled": True,
         "jwt_secret": "configured-secret",
+        "auth0_domain": "demo.auth0.example",
+        "auth0_client_id": "auth0-demo-client",
+        "auth0_client_secret": "configured-secret",
+        "auth0_callback_url": "http://127.0.0.1:18080/auth/auth0/callback",
+        "entra_tenant_id": "common",
+        "entra_client_id": "entra-demo-client",
+        "scalekit_environment_url": "https://demo.scalekit.com",
+        "scalekit_client_id": "scalekit-demo-client",
+        "scalekit_client_secret": "configured-secret",
     },
     "attribute_policies": [
         {
@@ -258,7 +276,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_html(page("Workflow Tailnet Demo Login", f"""
               <section class="card login-shell">
                 <h1>Sign in</h1>
-                <p>Use <code>admin@tailnet</code>/<code>admin</code>, <code>readonly-admin@tailnet</code>/<code>readonly</code>, or <code>app-user@tailnet</code>/<code>user</code>.</p>
+                <p>Use <code>admin@tailnet</code>/<code>admin</code>, <code>provider-admin@tailnet</code>/<code>provider</code>, <code>readonly-admin@tailnet</code>/<code>readonly</code>, or <code>app-user@tailnet</code>/<code>user</code>.</p>
                 <form method="post" action="/login">
                   <input type="hidden" name="next" value="{escape(next_token)}" />
                   <input name="email" type="email" placeholder="Email" required />
@@ -482,6 +500,14 @@ class Handler(BaseHTTPRequestHandler):
                 return
             self.send_json(auth_admin_describe_output())
             return
+        if path in {"/api/admin/auth/providers", "/api/admin/auth/catalog"}:
+            if not self.require_scope("admin:auth.providers:read"):
+                return
+            catalog = auth_provider_catalog_output()
+            if path == "/api/admin/auth/catalog":
+                catalog = {"provider_catalog": catalog, "auth_admin": auth_admin_describe_output()}
+            self.send_json(catalog)
+            return
         if path == "/api/admin/contributions":
             if not self.require_scope("admin:dashboard:read"):
                 return
@@ -494,7 +520,7 @@ class Handler(BaseHTTPRequestHandler):
             with state_lock:
                 flag = state["flag"]
                 requests = list(state["requests"])
-            self.send_json({"app": "workflow-tailnet-admin-demo", "uptimeSeconds": round(time.time() - started_at, 1), "featureFlag": flag, "requests": requests, "admin": {"auth": auth_admin_capabilities(), "authz": provider_capabilities(), "views": ["auth", "authz", "application", "audit"], "declarations": authz_declarations()}})
+            self.send_json({"app": "workflow-tailnet-admin-demo", "uptimeSeconds": round(time.time() - started_at, 1), "featureFlag": flag, "requests": requests, "admin": {"auth": auth_admin_capabilities(), "auth_provider_catalog": auth_provider_catalog_output(), "authz": provider_capabilities(), "views": ["auth", "authz", "application", "audit"], "declarations": authz_declarations()}})
             return
         self.send_error(HTTPStatus.NOT_FOUND)
 
@@ -572,6 +598,21 @@ class Handler(BaseHTTPRequestHandler):
                     self.send_html(page("Invalid Auth Settings", f"<h1>Invalid Auth Settings</h1><p class='error'>{escape(message)}</p><p><a href='/admin/auth'>Back to authentication</a></p>", principal), HTTPStatus.BAD_REQUEST)
                 return
             self.send_json(result, HTTPStatus.OK if result["valid"] else HTTPStatus.BAD_REQUEST)
+            return
+        if path == "/api/admin/auth/providers/config":
+            if not self.require_scope("admin:auth.providers:update"):
+                return
+            payload = self.json_payload(form)
+            result = auth_provider_config_validate(payload)
+            if not result["valid"]:
+                self.send_json(result, HTTPStatus.BAD_REQUEST)
+                return
+            with state_lock:
+                state["auth_config"].update(result["accepted_config"])
+                for field in result["secret_fields"]:
+                    state["auth_config"][field] = "configured-secret"
+                state["audit"].append({"event": "auth.provider_config.updated", "actor": principal})
+            self.send_json(result)
             return
         if path == "/admin/authz/abac/upsert":
             if not self.require_scope("admin:authz.policies:update", html=True):
@@ -865,8 +906,132 @@ def auth_admin_capabilities():
     return {
         "module": "workflow-plugin-auth",
         "provider": "workflow-plugin-auth admin-config-contract",
-        "capabilities": ["describe_config", "validate_config_patch", "secret_redaction"],
+        "capabilities": ["describe_config", "provider_catalog", "validate_config_patch", "secret_redaction"],
         "health": "ok",
+    }
+
+
+def auth_provider_catalog_output():
+    providers = auth_provider_descriptors()
+    return {
+        "contract": "workflow.plugins.auth.v1.AuthProviderCatalogOutput",
+        "provider_count": len(providers),
+        "providers": providers,
+        "source": "workflow-plugin-auth provider descriptor catalog",
+    }
+
+
+def auth_provider_descriptors():
+    return [
+        provider_descriptor(
+            "local-auth",
+            "Local authentication",
+            "workflow-plugin-auth",
+            "v0.2.11",
+            ["authentication_method"],
+            [
+                capability_descriptor("passkey", "Passkeys", "authentication_method", ["admin:auth.settings:read"], ["admin:auth.settings:update"], [
+                    provider_field("webauthn_rp_id", "Passkey relying party ID", "text", "Domain used to scope passkey credentials.", "Use the effective application host.", False, True),
+                    provider_field("webauthn_origin", "Passkey origin", "url", "Origin that WebAuthn challenges must be created for.", "HTTPS is required outside localhost development.", False, True),
+                ]),
+                capability_descriptor("password", "Password login", "authentication_method", ["admin:auth.settings:read"], ["admin:auth.settings:update"], [
+                    provider_field("password_auth_enabled", "Password login", "toggle", "Allows password sign-in outside production.", "Production policy blocks password login even when enabled.", False, False),
+                ]),
+            ],
+        ),
+        provider_descriptor("generic-oidc", "Generic OIDC", "workflow-plugin-sso", "v0.1.6", ["oauth2_oidc"], [oidc_capability("generic_oidc", "Generic OIDC", [
+            provider_field("generic_oidc_issuer_url", "Issuer URL", "url", "OIDC issuer discovery URL.", "Use the issuer from the provider metadata.", False, True),
+            provider_field("generic_oidc_client_id", "Client ID", "text", "OIDC client identifier.", "Pair with a write-only client secret.", False, True),
+            provider_field("generic_oidc_client_secret", "Client secret", "secret", "OIDC client secret.", "Write-only. Leave blank to keep a configured value.", True, True),
+            provider_field("generic_oidc_scopes", "OIDC scopes", "select", "Scopes requested during authorization.", "Choose only scopes required by the app.", False, True, [
+                {"value": "openid profile email", "label": "openid profile email"},
+                {"value": "openid profile email groups", "label": "openid profile email groups"},
+            ]),
+        ])]),
+        provider_descriptor("okta", "Okta", "workflow-plugin-okta", "v0.2.4", ["identity_management", "oauth2_oidc", "enterprise_sso", "directory_sync"], [oidc_capability("okta_oidc", "Okta OIDC", [
+            provider_field("okta_org_url", "Okta org URL", "url", "Okta organization base URL.", "Example: https://dev-123456.okta.com", False, True),
+            provider_field("okta_client_id", "Client ID", "text", "Okta OIDC client identifier.", "Use a dedicated app integration.", False, True),
+            provider_field("okta_client_secret", "Client secret", "secret", "Okta OIDC client secret.", "Write-only. Store in Workflow secrets.", True, True),
+        ])]),
+        provider_descriptor("auth0", "Auth0", "workflow-plugin-auth0", "v0.1.0", ["identity_management", "oauth2_oidc"], [oidc_capability("auth0_oidc", "Auth0 OIDC", [
+            provider_field("auth0_domain", "Auth0 domain", "text", "Auth0 tenant domain.", "Example: example.us.auth0.com", False, True),
+            provider_field("auth0_client_id", "Auth0 client ID", "text", "Auth0 application client identifier.", "Use Authorization Code with PKCE.", False, True),
+            provider_field("auth0_client_secret", "Auth0 client secret", "secret", "Auth0 application client secret.", "Write-only. Leave blank to keep a configured secret.", True, True),
+            provider_field("auth0_callback_url", "Auth0 callback URL", "url", "Callback URL registered with Auth0.", "Must exactly match the Auth0 application callback.", False, True),
+        ])]),
+        provider_descriptor("entra", "Microsoft Entra ID", "workflow-plugin-entra", "v0.1.0", ["identity_management", "oauth2_oidc", "enterprise_sso", "directory_sync"], [oidc_capability("entra_oidc", "Entra OIDC", [
+            provider_field("entra_tenant_id", "Tenant ID", "text", "Microsoft tenant ID or common endpoint.", "Use a tenant-specific ID for production.", False, True),
+            provider_field("entra_client_id", "Application client ID", "text", "Microsoft app registration client ID.", "Use a dedicated app registration.", False, True),
+            provider_field("entra_client_secret", "Application client secret", "secret", "Microsoft app client secret.", "Write-only. Prefer certificate auth where supported.", True, True),
+        ])]),
+        provider_descriptor("ory-kratos", "Ory Kratos", "workflow-plugin-ory-kratos", "v0.1.0", ["identity_management", "authentication_method"], [
+            capability_descriptor("kratos_identity", "Identity management", "identity_management", ["admin:auth.providers:read"], ["admin:auth.providers:update"], [
+                provider_field("kratos_admin_url", "Admin URL", "url", "Kratos admin API URL.", "Keep this server-side only.", False, True),
+                provider_field("kratos_session_cookie_name", "Session cookie", "text", "Kratos session cookie name.", "Used by application middleware.", False, False),
+            ]),
+        ]),
+        provider_descriptor("ory-hydra", "Ory Hydra", "workflow-plugin-ory-hydra", "v0.1.0", ["oauth2_oidc"], [oidc_capability("hydra_oauth2", "Hydra OAuth2/OIDC", [
+            provider_field("hydra_admin_url", "Hydra admin URL", "url", "Hydra admin API URL.", "Keep this server-side only.", False, True),
+            provider_field("hydra_public_issuer_url", "Issuer URL", "url", "Hydra public issuer URL.", "Used for token validation.", False, True),
+        ])]),
+        provider_descriptor("ory-polis", "Ory Polis", "workflow-plugin-ory-polis", "v0.1.0", ["enterprise_sso", "directory_sync"], [
+            capability_descriptor("polis_enterprise_sso", "Enterprise SSO", "enterprise_sso", ["admin:auth.providers:read"], ["admin:auth.providers:update"], [
+                provider_field("polis_api_url", "Polis API URL", "url", "Polis API base URL.", "Use the internal administration URL.", False, True),
+                provider_field("polis_api_token", "Polis API token", "secret", "Polis API token.", "Write-only. Store in Workflow secrets.", True, True),
+            ]),
+        ]),
+        provider_descriptor("scalekit", "Scalekit", "workflow-plugin-scalekit", "v0.1.0", ["enterprise_sso", "directory_sync"], [
+            capability_descriptor("scalekit_connections", "SSO connections", "enterprise_sso", ["admin:auth.providers:read"], ["admin:auth.providers:update"], [
+                provider_field("scalekit_environment_url", "Environment URL", "url", "Scalekit environment URL.", "Use the value from Scalekit API configuration.", False, True),
+                provider_field("scalekit_client_id", "Client ID", "text", "Scalekit environment client ID.", "Pair with the matching client secret.", False, True),
+                provider_field("scalekit_client_secret", "Client secret", "secret", "Scalekit environment client secret.", "Write-only. Store in Workflow secrets.", True, True),
+            ]),
+        ]),
+    ]
+
+
+def provider_descriptor(provider_id, label, implementation, version, categories, capabilities):
+    return {
+        "id": provider_id,
+        "label": label,
+        "description": f"{label} descriptor exposed by {implementation}.",
+        "categories": categories,
+        "implementation": implementation,
+        "version": version,
+        "docs_url": f"https://github.com/GoCodeAlone/{implementation}",
+        "support_level": "management",
+        "capabilities": capabilities,
+    }
+
+
+def oidc_capability(key, label, fields):
+    return capability_descriptor(key, label, "oauth2_oidc", ["admin:auth.providers:read"], ["admin:auth.providers:update"], fields)
+
+
+def capability_descriptor(key, label, category, read_scopes, write_scopes, fields):
+    return {
+        "key": key,
+        "label": label,
+        "category": category,
+        "description": f"{label} configuration and management contract.",
+        "supported": True,
+        "app_scopes": [],
+        "admin_read_scopes": read_scopes,
+        "admin_write_scopes": write_scopes,
+        "config_fields": fields,
+    }
+
+
+def provider_field(key, label, input_type, description, help_text, secret, required, options=None):
+    return {
+        "key": key,
+        "label": label,
+        "input_type": input_type,
+        "description": description,
+        "help_text": help_text,
+        "secret": secret,
+        "required": required,
+        "options": options or [],
     }
 
 
@@ -880,6 +1045,7 @@ def auth_admin_describe_output():
         "methods_policy": policy,
         "warnings": auth_admin_warnings(config, policy),
         "secret_fields": auth_admin_secret_fields(config),
+        "provider_catalog": auth_provider_catalog_output(),
     }
 
 
@@ -897,6 +1063,13 @@ def render_auth_admin_control(control, effective_config):
     elif control["input_type"] == "secret":
         placeholder = "Configured - leave blank to keep" if control.get("configured") else "Enter secret value"
         field = f"<input aria-label='{label}' title='{title}' type='password' name='{escape(key)}' placeholder='{escape(placeholder)}'{disabled} />"
+    elif control["input_type"] == "select":
+        selected_value = str(effective_config.get(key, "") or "")
+        options = "".join(
+            f"<option value='{escape(option['value'])}'{' selected' if option['value'] == selected_value else ''}>{escape(option.get('label') or option['value'])}</option>"
+            for option in control.get("options", [])
+        )
+        field = f"<select aria-label='{label}' title='{title}' name='{escape(key)}'{disabled}>{options}</select>"
     else:
         value = "" if control.get("secret") else str(effective_config.get(key, "") or "")
         input_type = "url" if control["input_type"] == "url" else "text"
@@ -936,6 +1109,48 @@ def auth_admin_validate_output(desired_config, require_primary_method=True):
     }
 
 
+def auth_provider_config_validate(payload):
+    if not isinstance(payload, dict):
+        return {"valid": False, "errors": [auth_admin_diagnostic("payload", "error", "provider config must be an object")], "accepted_config": {}, "secret_fields": []}
+    provider_id = str(payload.get("provider_id", "") or "").strip()
+    desired_config = payload.get("desired_config", {})
+    if not isinstance(desired_config, dict):
+        return {"valid": False, "errors": [auth_admin_diagnostic("desired_config", "error", "desired_config must be an object")], "accepted_config": {}, "secret_fields": []}
+    providers = {provider["id"]: provider for provider in auth_provider_descriptors()}
+    provider = providers.get(provider_id)
+    if not provider:
+        return {"valid": False, "errors": [auth_admin_diagnostic("provider_id", "error", "provider_id must come from the provider catalog")], "accepted_config": {}, "secret_fields": []}
+    allowed_fields = {}
+    required_fields = set()
+    secret_fields = set()
+    for capability in provider.get("capabilities", []):
+        for field in capability.get("config_fields", []):
+            allowed_fields[field["key"]] = field
+            if field.get("required"):
+                required_fields.add(field["key"])
+            if field.get("secret"):
+                secret_fields.add(field["key"])
+    errors = []
+    for key in desired_config:
+        if key not in allowed_fields:
+            errors.append(auth_admin_diagnostic(key, "error", f"{key} is not declared for provider {provider_id}"))
+    with state_lock:
+        merged = dict(state["auth_config"])
+    merged.update(desired_config)
+    for key in sorted(required_fields):
+        if not auth_admin_present(merged, key):
+            errors.append(auth_admin_diagnostic(key, "error", f"{key} is required for provider {provider_id}"))
+    accepted = auth_admin_sanitize_config({key: value for key, value in desired_config.items() if key in allowed_fields and key not in secret_fields})
+    submitted_secrets = sorted(key for key in desired_config if key in secret_fields and auth_admin_present(desired_config, key))
+    return {
+        "valid": not errors,
+        "provider_id": provider_id,
+        "accepted_config": accepted,
+        "errors": errors,
+        "secret_fields": submitted_secrets,
+    }
+
+
 def auth_admin_groups(config):
     groups = [
         {
@@ -969,8 +1184,8 @@ def auth_admin_groups(config):
         },
         {
             "key": "oauth_providers",
-            "label": "OAuth providers",
-            "description": "External identity providers available to auth routes.",
+            "label": "Provider catalog",
+            "description": "External identity and enterprise SSO providers rendered from registered plugin descriptors.",
             "controls": auth_admin_oauth_controls(config),
         },
     ]
@@ -981,15 +1196,17 @@ def auth_admin_groups(config):
 
 
 def auth_admin_oauth_controls(config):
+    descriptors = auth_provider_descriptors()
     controls = [
-        auth_admin_control(config, "auth_routes_enabled", "Auth routes", "toggle", "Enables HTTP auth routes used by OAuth callback flows.", "OAuth login requires auth routes before any provider can become login-ready."),
+        auth_admin_control(config, "auth_routes_enabled", "Auth routes", "toggle", "Enables HTTP auth routes used by OAuth callback flows.", "OAuth login requires auth routes before any OIDC provider can become login-ready."),
+        auth_admin_control_with_options(config, "active_auth_provider", "Active login provider", "select", "Provider selected from the merged descriptor catalog.", "Choices are registered by provider plugins, not embedded in the UI.", [{"value": provider["id"], "label": f"{provider['label']} ({provider['implementation']})"} for provider in descriptors]),
     ]
-    for provider, label in [("google", "Google"), ("facebook", "Facebook"), ("instagram", "Instagram"), ("x", "X")]:
-        disabled = auth_admin_provider_disabled_reason(provider)
-        controls.append(auth_admin_control(config, f"{provider}_oauth_client_id", f"{label} client ID", "text", f"OAuth client identifier issued by {label}.", "Pair with the matching client secret and redirect URL.", disabled_reason=disabled))
-        controls.append(auth_admin_control(config, f"{provider}_oauth_client_secret", f"{label} client secret", "secret", f"OAuth client secret issued by {label}.", "Write-only. Leave blank to keep an existing configured value.", disabled_reason=disabled))
-        if provider in {"google", "facebook"}:
-            controls.append(auth_admin_control(config, f"{provider}_oauth_redirect_url", f"{label} redirect URL", "url", f"Callback URL registered with {label}.", "Must be HTTPS and match the provider application settings.", disabled_reason=disabled))
+    for provider in descriptors:
+        for capability in provider.get("capabilities", []):
+            if capability.get("category") not in {"oauth2_oidc", "enterprise_sso", "directory_sync", "identity_management"}:
+                continue
+            for field in capability.get("config_fields", []):
+                controls.append(auth_admin_control_from_provider_field(config, provider, capability, field))
     return controls
 
 
@@ -1009,6 +1226,32 @@ def auth_admin_control(config, key, label, input_type, description, help_text, d
         "disabled_reason": disabled_reason,
         "options": [],
     }
+
+
+def auth_admin_control_with_options(config, key, label, input_type, description, help_text, options, disabled_reason=""):
+    control = auth_admin_control(config, key, label, input_type, description, help_text, disabled_reason)
+    control["options"] = options
+    return control
+
+
+def auth_admin_control_from_provider_field(config, provider, capability, field):
+    prefix = provider["label"]
+    control = auth_admin_control(
+        config,
+        field["key"],
+        f"{prefix} {field['label']}",
+        field["input_type"],
+        f"{field['description']} Source: {provider['implementation']} {provider['version']} capability {capability['key']}.",
+        field["help_text"],
+        disabled_reason="" if field.get("required") or field.get("secret") or field.get("options") is not None else "",
+    )
+    control["secret"] = bool(field.get("secret"))
+    control["required"] = bool(field.get("required"))
+    control["configured"] = auth_admin_present(config, field["key"])
+    control["options"] = field.get("options", [])
+    control["provider_id"] = provider["id"]
+    control["capability_key"] = capability["key"]
+    return control
 
 
 def auth_admin_methods_policy(config):

--- a/scenarios/90-admin-tailnet-demo/docker-compose.yml
+++ b/scenarios/90-admin-tailnet-demo/docker-compose.yml
@@ -41,7 +41,21 @@ services:
       - NET_RAW
     devices:
       - /dev/net/tun:/dev/net/tun
-    command: sh -c 'if [ -n "$$TS_AUTHKEY" ]; then tailscaled --state=$$TS_STATE_DIR/tailscaled.state & sleep 2 && tailscale up --authkey=$$TS_AUTHKEY --hostname=$$TS_HOSTNAME && tailscale serve --bg --http=80 http://app:8080 && wait; else echo "TS_AUTHKEY not set; sidecar idle" && sleep infinity; fi'
+    command: >
+      sh -c '
+        tailscaled --state=$$TS_STATE_DIR/tailscaled.state &
+        sleep 2
+        if tailscale status >/dev/null 2>&1; then
+          echo "tailscale sidecar using existing state"
+        elif [ -n "$$TS_AUTHKEY" ]; then
+          tailscale up --authkey=$$TS_AUTHKEY --hostname=$$TS_HOSTNAME
+        else
+          echo "TS_AUTHKEY not set and no reusable state; sidecar idle"
+          wait
+        fi
+        tailscale serve --bg --http=80 http://app:8080 || true
+        wait
+      '
     depends_on:
       app:
         condition: service_healthy

--- a/scenarios/90-admin-tailnet-demo/test/playwright-authz-qa.sh
+++ b/scenarios/90-admin-tailnet-demo/test/playwright-authz-qa.sh
@@ -44,7 +44,7 @@ playwright screenshot \
 
 playwright screenshot \
   --load-storage "$ADMIN_STATE" \
-  --wait-for-selector 'text=Google client secret' \
+  --wait-for-selector 'text=Auth0 client secret' \
   --full-page \
   "$BASE/admin/auth?group=oauth_providers" \
   "$ARTIFACT_DIR/admin-auth-oauth.png" >/dev/null

--- a/scenarios/90-admin-tailnet-demo/test/run.sh
+++ b/scenarios/90-admin-tailnet-demo/test/run.sh
@@ -5,9 +5,10 @@ BASE="${BASE:-http://127.0.0.1:18080}"
 COOKIE_JAR="$(mktemp)"
 FRONTEND_COOKIE="$(mktemp)"
 MALICIOUS_COOKIE="$(mktemp)"
+PROVIDER_COOKIE="$(mktemp)"
 PASS_COUNT=0
 FAIL_COUNT=0
-trap 'rm -f "$COOKIE_JAR" "$FRONTEND_COOKIE" "$MALICIOUS_COOKIE"' EXIT
+trap 'rm -f "$COOKIE_JAR" "$FRONTEND_COOKIE" "$MALICIOUS_COOKIE" "$PROVIDER_COOKIE"' EXIT
 
 pass() { echo "PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
 fail() { echo "FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
@@ -20,6 +21,20 @@ contains() {
     pass "$label"
   else
     fail "$label missing pattern: $pattern"
+  fi
+}
+
+validate_provider_config() {
+  local provider="$1"
+  local payload="$2"
+  local label="$3"
+  local response
+  response="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d "$payload" "$BASE/api/admin/auth/providers/config")"
+  contains "$response" '"valid": true' "$label"
+  if grep -q 'rotation-secret' <<<"$response"; then
+    fail "$label should redact submitted provider secrets"
+  else
+    pass "$label redacts submitted provider secrets"
   fi
 }
 
@@ -68,7 +83,11 @@ auth_config="$(curl -b "$COOKIE_JAR" -fsS "$BASE/api/admin/auth/config")"
 contains "$auth_config" '"groups"' "Auth admin config exposes control groups"
 contains "$auth_config" '"config_key": "webauthn_rp_id"' "Auth admin config maps passkey RP ID to real config key"
 contains "$auth_config" '"config_key": "password_auth_enabled"' "Auth admin config maps password toggle to real config key"
-contains "$auth_config" '"Google client secret"' "Auth admin config exposes OAuth secret control metadata"
+contains "$auth_config" '"provider_catalog"' "Auth admin config includes provider catalog"
+contains "$auth_config" '"workflow-plugin-auth0"' "Auth admin config includes Auth0 provider descriptor"
+contains "$auth_config" '"workflow-plugin-entra"' "Auth admin config includes Entra provider descriptor"
+contains "$auth_config" '"workflow-plugin-scalekit"' "Auth admin config includes Scalekit provider descriptor"
+contains "$auth_config" '"Auth0 client secret"' "Auth admin config exposes descriptor-backed OAuth secret control metadata"
 contains "$auth_config" '"secret_fields"' "Auth admin config declares write-only secret fields"
 if grep -q 'configured-secret' <<<"$auth_config"; then
   fail "Auth admin config should not echo configured secret values"
@@ -83,7 +102,7 @@ else
   fail "Auth admin unsafe password expected 400 with diagnostic, got $unsafe_auth_status"
 fi
 
-safe_auth="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d '{"require_primary_method":true,"desired_config":{"environment":"development","webauthn_rp_id":"tailnet-demo.local","webauthn_origin":"http://127.0.0.1:18080","google_oauth_client_secret":"new-secret"}}' "$BASE/api/admin/auth/config/validate")"
+safe_auth="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d '{"require_primary_method":true,"desired_config":{"environment":"development","webauthn_rp_id":"tailnet-demo.local","webauthn_origin":"http://127.0.0.1:18080","auth0_client_secret":"new-secret"}}' "$BASE/api/admin/auth/config/validate")"
 contains "$safe_auth" '"valid": true' "Auth admin accepts safe passkey config patch"
 contains "$safe_auth" '"webauthn_rp_id": "tailnet-demo.local"' "Auth admin returns accepted non-secret config"
 if grep -q 'new-secret' <<<"$safe_auth"; then
@@ -105,8 +124,58 @@ else
   pass "Auth admin UI does not display secret values"
 fi
 auth_oauth_page="$(curl -b "$COOKIE_JAR" -fsS "$BASE/admin/auth?group=oauth_providers")"
-contains "$auth_oauth_page" "Google client secret" "Auth admin OAuth tab labels Google secret"
+contains "$auth_oauth_page" "Provider catalog" "Auth admin provider tab is descriptor-backed"
+contains "$auth_oauth_page" "Active login provider" "Auth admin provider tab uses selectable provider choices"
+contains "$auth_oauth_page" "Auth0 client secret" "Auth admin provider tab labels Auth0 secret"
+contains "$auth_oauth_page" "Scalekit Client secret" "Auth admin provider tab labels Scalekit secret"
 contains "$auth_oauth_page" "Write-only" "Auth admin OAuth tab explains write-only secrets"
+
+provider_catalog="$(curl -b "$COOKIE_JAR" -fsS "$BASE/api/admin/auth/providers")"
+contains "$provider_catalog" '"provider_count": 9' "Provider catalog exposes all composed providers"
+contains "$provider_catalog" '"id": "generic-oidc"' "Provider catalog includes generic OIDC"
+contains "$provider_catalog" '"id": "okta"' "Provider catalog includes Okta"
+contains "$provider_catalog" '"id": "auth0"' "Provider catalog includes Auth0"
+contains "$provider_catalog" '"id": "entra"' "Provider catalog includes Entra"
+contains "$provider_catalog" '"id": "ory-kratos"' "Provider catalog includes Ory Kratos"
+contains "$provider_catalog" '"id": "ory-hydra"' "Provider catalog includes Ory Hydra"
+contains "$provider_catalog" '"id": "ory-polis"' "Provider catalog includes Ory Polis"
+contains "$provider_catalog" '"id": "scalekit"' "Provider catalog includes Scalekit"
+contains "$provider_catalog" '"config_fields"' "Provider catalog exposes lookup-backed field descriptors"
+
+provider_save="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d '{"provider_id":"auth0","desired_config":{"auth0_domain":"demo.auth0.example","auth0_client_id":"updated-client"}}' "$BASE/api/admin/auth/providers/config")"
+contains "$provider_save" '"valid": true' "Auth admin can save accepted non-secret provider config"
+pass "Provider config save has no submitted secret to echo"
+
+validate_provider_config "local-auth" '{"provider_id":"local-auth","desired_config":{"webauthn_rp_id":"tailnet-demo.local","webauthn_origin":"http://127.0.0.1:18080"}}' "Provider rotation validates local auth"
+validate_provider_config "generic-oidc" '{"provider_id":"generic-oidc","desired_config":{"generic_oidc_issuer_url":"https://issuer.example.test","generic_oidc_client_id":"generic-client","generic_oidc_client_secret":"rotation-secret","generic_oidc_scopes":"openid profile email"}}' "Provider rotation validates generic OIDC"
+validate_provider_config "okta" '{"provider_id":"okta","desired_config":{"okta_org_url":"https://dev-123456.okta.com","okta_client_id":"okta-client","okta_client_secret":"rotation-secret"}}' "Provider rotation validates Okta"
+validate_provider_config "auth0" '{"provider_id":"auth0","desired_config":{"auth0_domain":"demo.auth0.example","auth0_client_id":"auth0-client","auth0_client_secret":"rotation-secret","auth0_callback_url":"http://127.0.0.1:18080/auth/auth0/callback"}}' "Provider rotation validates Auth0"
+validate_provider_config "entra" '{"provider_id":"entra","desired_config":{"entra_tenant_id":"common","entra_client_id":"entra-client","entra_client_secret":"rotation-secret"}}' "Provider rotation validates Entra"
+validate_provider_config "ory-kratos" '{"provider_id":"ory-kratos","desired_config":{"kratos_admin_url":"http://kratos.example.test/admin","kratos_session_cookie_name":"ory_kratos_session"}}' "Provider rotation validates Ory Kratos"
+validate_provider_config "ory-hydra" '{"provider_id":"ory-hydra","desired_config":{"hydra_admin_url":"http://hydra.example.test/admin","hydra_public_issuer_url":"https://hydra.example.test/"}}' "Provider rotation validates Ory Hydra"
+validate_provider_config "ory-polis" '{"provider_id":"ory-polis","desired_config":{"polis_api_url":"https://polis.example.test","polis_api_token":"rotation-secret"}}' "Provider rotation validates Ory Polis"
+validate_provider_config "scalekit" '{"provider_id":"scalekit","desired_config":{"scalekit_environment_url":"https://demo.scalekit.com","scalekit_client_id":"scalekit-client","scalekit_client_secret":"rotation-secret"}}' "Provider rotation validates Scalekit"
+
+invalid_provider_status="$(curl -b "$COOKIE_JAR" -s -o /dev/null -w "%{http_code}" -H 'content-type: application/json' -d '{"provider_id":"unknown","desired_config":{}}' "$BASE/api/admin/auth/providers/config")"
+if [[ "$invalid_provider_status" == "400" ]]; then
+  pass "Unknown provider config fails closed"
+else
+  fail "Unknown provider config expected 400, got $invalid_provider_status"
+fi
+
+curl -s -o /dev/null -c "$PROVIDER_COOKIE" -d 'email=provider-admin@tailnet&password=provider' "$BASE/login"
+provider_page_status="$(curl -b "$PROVIDER_COOKIE" -s -o /dev/null -w "%{http_code}" "$BASE/admin/auth?group=oauth_providers")"
+if [[ "$provider_page_status" == "200" ]]; then
+  pass "Provider admin can view descriptor-backed provider controls"
+else
+  fail "Provider admin expected auth provider page 200, got $provider_page_status"
+fi
+provider_write_status="$(curl -b "$PROVIDER_COOKIE" -s -o /dev/null -w "%{http_code}" -H 'content-type: application/json' -d '{"provider_id":"auth0","desired_config":{"auth0_client_secret":"readonly-secret"}}' "$BASE/api/admin/auth/providers/config")"
+if [[ "$provider_write_status" == "403" ]]; then
+  pass "Provider admin without write scope cannot save secrets"
+else
+  fail "Provider admin secret save expected 403, got $provider_write_status"
+fi
 
 authz="$(curl -b "$COOKIE_JAR" -fsS "$BASE/admin/authz")"
 contains "$authz" "Role and Scope Administration" "Authz UI page renders"


### PR DESCRIPTION
## Summary
- add descriptor-backed auth provider catalog to scenario 90 for local auth, generic OIDC, Okta, Auth0, Entra, Ory Kratos/Hydra/Polis, and Scalekit
- render auth provider admin controls from descriptor config fields and split read/write provider scopes
- expand runtime QA for provider config rotation, secret redaction, Keto and memory authz enforcement, Playwright screenshots, and tailnet reachability

## Verification
- python3 -m py_compile scenarios/90-admin-tailnet-demo/app/app.py
- python3 -m json.tool scenarios.json
- git diff --check
- docker compose config
- docker compose up -d --build app keto tailscale
- ./test/run.sh (129 passed, 0 failed)
- ./test/playwright-authz-qa.sh
- make validate (84/84 passed)
- AUTHZ_PROVIDER=memory runtime RBAC/ABAC/ReBAC smoke checks
- curl http://jonathans-macbook-pro.tail1905d6.ts.net:18080/api/status