### PR TITLE
feat(scenarios/92): infra-admin-demo + Playwright + EXPLORATORY template

### DIFF
--- a/e2e/tests/scenario-92-infra-admin.spec.ts
+++ b/e2e/tests/scenario-92-infra-admin.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { createHmac } from 'crypto';
 
 // Scenario 92 — Infra Admin (Dynamic, Proto-Driven)
 //
@@ -8,20 +9,73 @@ import { test, expect, type Page } from '@playwright/test';
 //
 // SCENARIO_URL points at the running stack (default http://127.0.0.1:18092
 // for scenario 92's port mapping). Override via env var.
+//
+// Auth: every /api/infra-admin/* and /admin/infra-admin/* request must
+// carry a Bearer JWT signed by the scenario's HS256 secret, since
+// PR-1 47341ff6f (T15 auth fix) added a route-level auth middleware.
+// The token is minted once in beforeAll and threaded through fetch
+// headers + page.setExtraHTTPHeaders for browser navigations.
 
 const BASE_URL = process.env.SCENARIO_URL || 'http://127.0.0.1:18092';
 
+// Must match config/app.yaml::modules[name=auth].config.hs256_secret.
+const JWT_SECRET = 'scenario-92-jwt-secret-do-not-use-in-prod';
+const JWT_ISSUER = 'scenario-92';
+
+function base64Url(buf: Buffer | string): string {
+  const b = Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
+  return b
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+// mintHS256JWT issues a self-signed JWT matching auth.jwt's HS256
+// verification path. Long expiry so a slow Playwright run never
+// rolls past it; sub identifies the e2e suite for any audit-log
+// breadcrumb that surfaces.
+function mintHS256JWT(): string {
+  const header = base64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = base64Url(
+    JSON.stringify({
+      iss: JWT_ISSUER,
+      sub: 'playwright-scenario-92',
+      iat: now,
+      exp: now + 3600,
+    }),
+  );
+  const unsigned = `${header}.${payload}`;
+  const signature = base64Url(
+    createHmac('sha256', JWT_SECRET).update(unsigned).digest(),
+  );
+  return `${unsigned}.${signature}`;
+}
+
+const BEARER_TOKEN = mintHS256JWT();
+const AUTH_HEADER = { Authorization: `Bearer ${BEARER_TOKEN}` };
+
 async function adminFetch(page: Page, path: string, body: unknown) {
   return page.evaluate(
-    async ([url, payload]) => {
+    async ([url, payload, auth]) => {
       const resp = await fetch(url as string, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: auth as string,
+        },
         body: JSON.stringify(payload),
       });
-      return { status: resp.status, body: await resp.json() };
+      let parsed: unknown = null;
+      try {
+        parsed = await resp.json();
+      } catch (_) {
+        /* not JSON — leave parsed null */
+      }
+      return { status: resp.status, body: parsed };
     },
-    [path, body] as const,
+    [path, body, AUTH_HEADER.Authorization] as const,
   );
 }
 
@@ -29,17 +83,71 @@ const EVIDENCE = { authz_checked: true, authz_allowed: true };
 
 // @scenario-92
 test.describe('Scenario 92: Infra Admin (Dynamic, Proto-Driven)', () => {
+  // Authenticate every browser navigation. /healthz is public (no
+  // auth middleware) so it's safe even when the header is sent; the
+  // /admin/infra-admin/* asset pages and /api/infra-admin/* RPCs
+  // require it per PR-1 T15 auth gate (47341ff6f).
+  test.beforeEach(async ({ page }) => {
+    await page.setExtraHTTPHeaders({ Authorization: `Bearer ${BEARER_TOKEN}` });
+  });
+
   test('@scenario-92 healthz OK', async ({ page }) => {
     const resp = await page.goto(`${BASE_URL}/healthz`);
     expect(resp?.status()).toBe(200);
   });
 
+  test('@scenario-92 unauthenticated /api/infra-admin/* returns 401', async ({
+    page,
+  }) => {
+    // PR-1 T15 auth-middleware regression gate. Without an
+    // Authorization header, the auth gate MUST return 401 BEFORE
+    // any handler runs — clients can't spoof the in-body evidence
+    // {authz_checked:true, authz_allowed:true} to bypass the
+    // application-level default-deny. Mirrors implementer-1's unit
+    // test TestInfraAdmin_ClientCannotSpoofAuthzEvidence at the e2e
+    // tier per spec-reviewer F2 (PR-2) + team-lead's option 2.
+    const { status, body } = await page.evaluate(async url => {
+      const resp = await fetch(`${url}/api/infra-admin/resources`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          evidence: { authz_checked: true, authz_allowed: true },
+        }),
+      });
+      let parsed: unknown = null;
+      try {
+        parsed = await resp.json();
+      } catch (_) {
+        /* not JSON — leave null */
+      }
+      return { status: resp.status, body: parsed };
+    }, BASE_URL);
+    expect(status).toBe(401);
+    // 401 is enforced by the auth middleware BEFORE the handler runs,
+    // so the body should NOT contain a handler-shaped
+    // `AdminListResourcesOutput` with a tag-100 error. Just assert no
+    // 200-shaped resources field — the 401 status is the load-bearing
+    // assertion here.
+    if (body && typeof body === 'object') {
+      expect((body as Record<string, unknown>).resources).toBeUndefined();
+    }
+  });
+
   test('@scenario-92 infra contributions auto-registered', async ({ page }) => {
     await page.goto(BASE_URL);
-    const data = await page.evaluate(async url => {
-      const resp = await fetch(`${url}/api/admin/contributions`);
-      return resp.json();
-    }, BASE_URL);
+    // /api/admin/contributions is gated by admin.dashboard's
+    // auth_module (matches infra.admin's gate); include the Bearer
+    // token explicitly since this fetch doesn't go through the
+    // setExtraHTTPHeaders-covered navigation path.
+    const data = await page.evaluate(
+      async ([url, auth]) => {
+        const resp = await fetch(`${url}/api/admin/contributions`, {
+          headers: { Authorization: auth as string },
+        });
+        return resp.json();
+      },
+      [BASE_URL, AUTH_HEADER.Authorization] as const,
+    );
     const contributions = (data?.contributions ?? []) as Array<{ id: string }>;
     const ids = contributions.map(c => c.id);
     expect(ids).toEqual(

--- a/e2e/tests/scenario-92-infra-admin.spec.ts
+++ b/e2e/tests/scenario-92-infra-admin.spec.ts
@@ -18,7 +18,7 @@ import { createHmac } from 'crypto';
 
 const BASE_URL = process.env.SCENARIO_URL || 'http://127.0.0.1:18092';
 
-// Must match config/app.yaml::modules[name=auth].config.hs256_secret.
+// Must match config/app.yaml::modules[name=auth].config.secret.
 const JWT_SECRET = 'scenario-92-jwt-secret-do-not-use-in-prod';
 const JWT_ISSUER = 'scenario-92';
 

--- a/e2e/tests/scenario-92-infra-admin.spec.ts
+++ b/e2e/tests/scenario-92-infra-admin.spec.ts
@@ -97,37 +97,40 @@ test.describe('Scenario 92: Infra Admin (Dynamic, Proto-Driven)', () => {
   });
 
   test('@scenario-92 unauthenticated /api/infra-admin/* returns 401', async ({
-    page,
+    request,
   }) => {
     // PR-1 T15 auth-middleware regression gate. Without an
     // Authorization header, the auth gate MUST return 401 BEFORE
     // any handler runs — clients can't spoof the in-body evidence
     // {authz_checked:true, authz_allowed:true} to bypass the
-    // application-level default-deny. Mirrors implementer-1's unit
-    // test TestInfraAdmin_ClientCannotSpoofAuthzEvidence at the e2e
-    // tier per spec-reviewer F2 (PR-2) + team-lead's option 2.
-    const { status, body } = await page.evaluate(async url => {
-      const resp = await fetch(`${url}/api/infra-admin/resources`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          evidence: { authz_checked: true, authz_allowed: true },
-        }),
-      });
-      let parsed: unknown = null;
-      try {
-        parsed = await resp.json();
-      } catch (_) {
-        /* not JSON — leave null */
-      }
-      return { status: resp.status, body: parsed };
-    }, BASE_URL);
-    expect(status).toBe(401);
+    // application-level default-deny.
+    //
+    // CRITICAL: uses the `request` fixture (fresh APIRequestContext
+    // with no inherited headers) NOT `page` — Playwright's
+    // setExtraHTTPHeaders() applies at the browser network layer to
+    // ALL browser-initiated requests, including fetch() inside
+    // page.evaluate. Using `page` here would silently leak the
+    // beforeEach-set Authorization header into this test and the
+    // request would be authenticated. Spec-reviewer PR-2 F1 catch.
+    //
+    // Mirrors implementer-1's unit test
+    // TestInfraAdmin_ClientCannotSpoofAuthzEvidence at the e2e tier.
+    const resp = await request.post(`${BASE_URL}/api/infra-admin/resources`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: { evidence: { authz_checked: true, authz_allowed: true } },
+    });
+    expect(resp.status()).toBe(401);
     // 401 is enforced by the auth middleware BEFORE the handler runs,
     // so the body should NOT contain a handler-shaped
     // `AdminListResourcesOutput` with a tag-100 error. Just assert no
     // 200-shaped resources field — the 401 status is the load-bearing
     // assertion here.
+    let body: unknown = null;
+    try {
+      body = await resp.json();
+    } catch (_) {
+      /* 401 body may not be JSON — leave null */
+    }
     if (body && typeof body === 'object') {
       expect((body as Record<string, unknown>).resources).toBeUndefined();
     }

--- a/e2e/tests/scenario-92-infra-admin.spec.ts
+++ b/e2e/tests/scenario-92-infra-admin.spec.ts
@@ -1,0 +1,223 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Scenario 92 — Infra Admin (Dynamic, Proto-Driven)
+//
+// Exercises the host-side infra.admin module + form-builder UI end-to-end
+// against the docker-compose stack from seed/seed.sh. Test ordering
+// matches the plan §Task 24 spec block.
+//
+// SCENARIO_URL points at the running stack (default http://127.0.0.1:18092
+// for scenario 92's port mapping). Override via env var.
+
+const BASE_URL = process.env.SCENARIO_URL || 'http://127.0.0.1:18092';
+
+async function adminFetch(page: Page, path: string, body: unknown) {
+  return page.evaluate(
+    async ([url, payload]) => {
+      const resp = await fetch(url as string, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      return { status: resp.status, body: await resp.json() };
+    },
+    [path, body] as const,
+  );
+}
+
+const EVIDENCE = { authz_checked: true, authz_allowed: true };
+
+// @scenario-92
+test.describe('Scenario 92: Infra Admin (Dynamic, Proto-Driven)', () => {
+  test('@scenario-92 healthz OK', async ({ page }) => {
+    const resp = await page.goto(`${BASE_URL}/healthz`);
+    expect(resp?.status()).toBe(200);
+  });
+
+  test('@scenario-92 infra contributions auto-registered', async ({ page }) => {
+    await page.goto(BASE_URL);
+    const data = await page.evaluate(async url => {
+      const resp = await fetch(`${url}/api/admin/contributions`);
+      return resp.json();
+    }, BASE_URL);
+    const contributions = (data?.contributions ?? []) as Array<{ id: string }>;
+    const ids = contributions.map(c => c.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(['infra.resources', 'infra.resource-detail', 'infra.new']),
+    );
+  });
+
+  test('@scenario-92 ListProviders returns at least the stub provider', async ({ page }) => {
+    await page.goto(BASE_URL);
+    const { status, body } = await adminFetch(page, `${BASE_URL}/api/infra-admin/providers`, {
+      evidence: EVIDENCE,
+    });
+    expect(status).toBe(200);
+    expect(body.providers?.length ?? 0).toBeGreaterThan(0);
+    const types = body.providers.map((p: { provider_type: string }) => p.provider_type);
+    expect(types).toContain('stub');
+  });
+
+  test('@scenario-92 ListResourceTypes returns all 13 typed Configs', async ({ page }) => {
+    await page.goto(BASE_URL);
+    const { status, body } = await adminFetch(page, `${BASE_URL}/api/infra-admin/types`, {
+      evidence: EVIDENCE,
+    });
+    expect(status).toBe(200);
+    const typeNames = (body.types ?? []).map((t: { type: string }) => t.type);
+    expect(typeNames).toEqual(
+      expect.arrayContaining([
+        'infra.vpc',
+        'infra.database',
+        'infra.container_service',
+        'infra.k8s_cluster',
+        'infra.cache',
+        'infra.load_balancer',
+        'infra.dns',
+        'infra.registry',
+        'infra.api_gateway',
+        'infra.firewall',
+        'infra.iam_role',
+        'infra.storage',
+        'infra.certificate',
+      ]),
+    );
+  });
+
+  test('@scenario-92 ListResources default-deny without evidence', async ({ page }) => {
+    await page.goto(BASE_URL);
+    const { status, body } = await adminFetch(page, `${BASE_URL}/api/infra-admin/resources`, {});
+    expect(status).toBe(200);
+    expect(body.error).toBeTruthy(); // tag-100 default-deny string
+  });
+
+  test('@scenario-92 resources.html serves and references resources.js', async ({ page }) => {
+    const resp = await page.goto(`${BASE_URL}/admin/infra-admin/resources.html`);
+    expect(resp?.status()).toBe(200);
+    const html = await page.content();
+    expect(html).toContain('Infra Resources');
+    expect(html).toMatch(/<script[^>]*src="\/admin\/infra-admin\/resources\.js"/);
+  });
+
+  test('@scenario-92 new.html form-builder loads and populates type dropdown', async ({ page }) => {
+    await page.goto(`${BASE_URL}/admin/infra-admin/new.html`);
+    // Wait for the loadCatalog fetch to populate the select.
+    await expect(page.locator('#type')).toBeVisible();
+    await page.waitForFunction(
+      () => {
+        const sel = document.getElementById('type') as HTMLSelectElement | null;
+        return sel != null && sel.options.length > 1;
+      },
+      undefined,
+      { timeout: 5000 },
+    );
+    const typeCount = await page.locator('#type option').count();
+    expect(typeCount).toBeGreaterThan(1); // "— select —" + at least one type
+  });
+
+  test('@scenario-92 new-resource form: provider dropdown populates after type select', async ({
+    page,
+  }) => {
+    await page.goto(`${BASE_URL}/admin/infra-admin/new.html`);
+    await page.waitForFunction(() => {
+      const sel = document.getElementById('type') as HTMLSelectElement | null;
+      return sel != null && sel.options.length > 1;
+    });
+    await page.selectOption('#type', 'infra.vpc');
+    // After type select, the provider field should render.
+    const providerSelect = page.locator('select[name="provider"]');
+    await expect(providerSelect).toBeVisible();
+    const optCount = await providerSelect.locator('option').count();
+    expect(optCount).toBeGreaterThan(1);
+  });
+
+  test('@scenario-92 new-resource form: region depends_on provider', async ({ page }) => {
+    await page.goto(`${BASE_URL}/admin/infra-admin/new.html`);
+    await page.waitForFunction(() => {
+      const sel = document.getElementById('type') as HTMLSelectElement | null;
+      return sel != null && sel.options.length > 1;
+    });
+    await page.selectOption('#type', 'infra.vpc');
+    await expect(page.locator('select[name="provider"]')).toBeVisible();
+    // Pick the first non-placeholder provider option.
+    const firstProvider = await page
+      .locator('select[name="provider"] option:not([value=""])')
+      .first()
+      .getAttribute('value');
+    expect(firstProvider).toBeTruthy();
+    await page.selectOption('select[name="provider"]', firstProvider!);
+    // After provider chosen, region dropdown should populate.
+    const regionSelect = page.locator('select[name="region"]');
+    await expect(regionSelect).toBeVisible();
+    await page.waitForFunction(() => {
+      const sel = document.querySelector(
+        'select[name="region"]',
+      ) as HTMLSelectElement | null;
+      return sel != null && sel.options.length > 1;
+    });
+    const regionCount = await regionSelect.locator('option').count();
+    expect(regionCount).toBeGreaterThan(1);
+  });
+
+  test('@scenario-92 generate-config returns YAML snippet', async ({ page }) => {
+    await page.goto(`${BASE_URL}/admin/infra-admin/new.html`);
+    await page.waitForFunction(() => {
+      const sel = document.getElementById('type') as HTMLSelectElement | null;
+      return sel != null && sel.options.length > 1;
+    });
+    await page.selectOption('#type', 'infra.vpc');
+    await page.fill('#name', 'demo-vpc');
+
+    // Pick first available provider + region.
+    const provVal = await page
+      .locator('select[name="provider"] option:not([value=""])')
+      .first()
+      .getAttribute('value');
+    await page.selectOption('select[name="provider"]', provVal!);
+    await page.waitForFunction(() => {
+      const sel = document.querySelector(
+        'select[name="region"]',
+      ) as HTMLSelectElement | null;
+      return sel != null && sel.options.length > 1;
+    });
+    const regionVal = await page
+      .locator('select[name="region"] option:not([value=""])')
+      .first()
+      .getAttribute('value');
+    await page.selectOption('select[name="region"]', regionVal!);
+
+    // VPC needs cidr.
+    await page.fill('input[name="cidr"]', '10.0.0.0/16');
+
+    await page.click('#submit');
+    await expect(page.locator('#yaml-output')).toContainText('infra.vpc');
+    await expect(page.locator('#yaml-output')).toContainText('demo-vpc');
+  });
+
+  test('@scenario-92 CSP enforces no inline scripts on asset pages', async ({ page }) => {
+    // Asset pages MUST NOT contain inline `<script>` tags with content
+    // (only external `src` references). This guards against the
+    // design-cycle-5 CSP regression class.
+    for (const path of ['resources.html', 'resource.html', 'new.html']) {
+      await page.goto(`${BASE_URL}/admin/infra-admin/${path}`);
+      const inlineScriptCount = await page.evaluate(() => {
+        return Array.from(document.querySelectorAll('script'))
+          .filter(s => !s.src && s.textContent && s.textContent.trim().length > 0)
+          .length;
+      });
+      expect(inlineScriptCount, `${path} has inline scripts`).toBe(0);
+    }
+  });
+
+  test('@scenario-92 full-page screenshot', async ({ page }) => {
+    await page.goto(`${BASE_URL}/admin/infra-admin/new.html`);
+    await page.waitForFunction(() => {
+      const sel = document.getElementById('type') as HTMLSelectElement | null;
+      return sel != null && sel.options.length > 1;
+    });
+    await page.screenshot({
+      path: 'test-results/scenario-92-new-form.png',
+      fullPage: true,
+    });
+  });
+});

--- a/e2e/tests/scenario-92-infra-admin.spec.ts
+++ b/e2e/tests/scenario-92-infra-admin.spec.ts
@@ -192,11 +192,19 @@ test.describe('Scenario 92: Infra Admin (Dynamic, Proto-Driven)', () => {
     );
   });
 
-  test('@scenario-92 ListResources default-deny without evidence', async ({ page }) => {
+  test('@scenario-92 authenticated request without evidence still default-denies', async ({
+    page,
+  }) => {
+    // Two-tier security check exercised together: auth gate passes
+    // (Bearer header set in adminFetch), but handler-library default-
+    // deny rejects because the body omits the AdminAuthzEvidence
+    // payload. Result is 200 with tag-100 error string (per design's
+    // "errors surface via Output.error not Go-level errors" contract).
+    // Spec-reviewer PR-2 review item #4.
     await page.goto(BASE_URL);
     const { status, body } = await adminFetch(page, `${BASE_URL}/api/infra-admin/resources`, {});
     expect(status).toBe(200);
-    expect(body.error).toBeTruthy(); // tag-100 default-deny string
+    expect((body as { error?: string }).error).toBeTruthy();
   });
 
   test('@scenario-92 resources.html serves and references resources.js', async ({ page }) => {

--- a/scenarios.json
+++ b/scenarios.json
@@ -1109,6 +1109,17 @@
       "notes": "Parent zone at stub-A delegates child.example.test to stub-B via NS records; child zone served at stub-B. Single `wfctl infra apply` reconciles both providers; subsequent imports assert the delegation survives via .applied_config.records[] jq matchers.",
       "lastTested": null,
       "lastResult": null
+    },
+    "92-infra-admin-demo": {
+      "status": "pending",
+      "namespace": "wf-scenario-92",
+      "deployed": false,
+      "lastTested": "",
+      "lastResult": "",
+      "testCount": 0,
+      "passCount": 0,
+      "failCount": 0,
+      "blockers": []
     }
   }
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1086,6 +1086,18 @@
       "lastTested": null,
       "lastResult": null
     },
+    "90-admin-tailnet-demo": {
+      "status": "testable",
+      "namespace": "local",
+      "deployed": false,
+      "testCount": 0,
+      "passCount": 0,
+      "failCount": 0,
+      "localOnly": true,
+      "notes": "Docker Compose app/admin demo with auth-gated admin portal, dynamic auth provider descriptor catalog, authz RBAC/ABAC/ReBAC UI, Ory Keto enforcement, and optional Tailscale sidecar.",
+      "lastTested": null,
+      "lastResult": null
+    },
     "91-dns-delegation": {
       "status": "draft",
       "namespace": "local",

--- a/scenarios/90-admin-tailnet-demo/README.md
+++ b/scenarios/90-admin-tailnet-demo/README.md
@@ -5,13 +5,28 @@ This scenario runs a small app with an auth-gated administration portal, a decla
 - App: <http://localhost:18080/>
 - Admin: <http://localhost:18080/admin>
 - Authz admin contribution: <http://localhost:18080/admin/authz>
+- Auth provider catalog API: <http://localhost:18080/api/admin/auth/providers>
 - Status API: <http://localhost:18080/api/status>
 
 Demo users:
 
 - `admin@tailnet` / `admin`: full admin and frontend scopes.
+- `provider-admin@tailnet` / `provider`: auth provider read-only admin.
 - `readonly-admin@tailnet` / `readonly`: admin read scopes only.
 - `app-user@tailnet` / `user`: frontend scopes only.
+
+The auth provider catalog composes descriptor-shaped records for released
+Workflow provider plugins:
+
+- `workflow-plugin-auth v0.2.11`
+- `workflow-plugin-sso v0.1.6`
+- `workflow-plugin-okta v0.2.4`
+- `workflow-plugin-auth0 v0.1.0`
+- `workflow-plugin-entra v0.1.0`
+- `workflow-plugin-ory-kratos v0.1.0`
+- `workflow-plugin-ory-hydra v0.1.0`
+- `workflow-plugin-ory-polis v0.1.0`
+- `workflow-plugin-scalekit v0.1.0`
 
 The authz contribution displays frontend and admin scopes from the declared scope catalog, including owner plugin/module metadata. The demo defaults to `AUTHZ_PROVIDER=keto`, runs a local Ory Keto container, and resolves role assignments into Keto scope relationship checks for the app/admin surfaces.
 

--- a/scenarios/90-admin-tailnet-demo/app/app.py
+++ b/scenarios/90-admin-tailnet-demo/app/app.py
@@ -28,6 +28,10 @@ users = {
         "password": "readonly",
         "scopes": ["admin:dashboard:read", "admin:authz.roles:read", "admin:authz.scopes:read"],
     },
+    "provider-admin@tailnet": {
+        "password": "provider",
+        "scopes": ["admin:dashboard:read", "admin:auth.settings:read", "admin:auth.providers:read"],
+    },
     "admin@tailnet": {
         "password": "admin",
         "scopes": [
@@ -37,6 +41,8 @@ users = {
             "admin:app:update",
             "admin:auth.settings:read",
             "admin:auth.settings:update",
+            "admin:auth.providers:read",
+            "admin:auth.providers:update",
             "admin:authz.roles:read",
             "admin:authz.roles:update",
             "admin:authz.scopes:read",
@@ -58,6 +64,8 @@ state = {
         {"name": "admin:app:update", "context": "admin", "resource": "app", "actions": ["update"], "description": "Update application operations from admin", "owner_plugin": "workflow-plugin-admin", "owner_module": "admin", "category": "admin"},
         {"name": "admin:auth.settings:read", "context": "admin", "resource": "auth.settings", "actions": ["read"], "description": "Inspect authentication plugin settings", "owner_plugin": "workflow-plugin-auth", "owner_module": "admin-config", "category": "security"},
         {"name": "admin:auth.settings:update", "context": "admin", "resource": "auth.settings", "actions": ["update"], "description": "Validate and update authentication plugin settings", "owner_plugin": "workflow-plugin-auth", "owner_module": "admin-config", "category": "security"},
+        {"name": "admin:auth.providers:read", "context": "admin", "resource": "auth.providers", "actions": ["read"], "description": "Inspect registered authentication provider descriptors", "owner_plugin": "workflow-plugin-auth", "owner_module": "provider-catalog", "category": "security"},
+        {"name": "admin:auth.providers:update", "context": "admin", "resource": "auth.providers", "actions": ["update"], "description": "Update authentication provider configuration", "owner_plugin": "workflow-plugin-auth", "owner_module": "provider-catalog", "category": "security"},
         {"name": "admin:authz.roles:read", "context": "admin", "resource": "authz.roles", "actions": ["read"], "description": "Inspect role assignments", "owner_plugin": "workflow-plugin-authz", "owner_module": "scope-catalog", "category": "security"},
         {"name": "admin:authz.roles:update", "context": "admin", "resource": "authz.roles", "actions": ["update"], "description": "Create and remove role assignments", "owner_plugin": "workflow-plugin-authz", "owner_module": "scope-catalog", "category": "security"},
         {"name": "admin:authz.scopes:read", "context": "admin", "resource": "authz.scopes", "actions": ["read"], "description": "Inspect declared application scopes", "owner_plugin": "workflow-plugin-authz", "owner_module": "scope-catalog", "category": "security"},
@@ -69,7 +77,8 @@ state = {
     "roles": [
         {"user": "app-user@tailnet", "role": "requester", "context": "frontend", "scopes": ["frontend:orders:read", "frontend:requests:create"]},
         {"user": "readonly-admin@tailnet", "role": "authz-viewer", "context": "admin", "scopes": ["admin:dashboard:read", "admin:authz.roles:read", "admin:authz.scopes:read"]},
-        {"user": "admin@tailnet", "role": "authz-admin", "context": "admin", "scopes": ["admin:dashboard:read", "admin:app:update", "admin:auth.settings:read", "admin:auth.settings:update", "admin:authz.roles:read", "admin:authz.roles:update", "admin:authz.scopes:read", "admin:authz.policies:read", "admin:authz.policies:update", "admin:authz.relations:read", "admin:authz.relations:update"]},
+        {"user": "provider-admin@tailnet", "role": "auth-provider-viewer", "context": "admin", "scopes": ["admin:dashboard:read", "admin:auth.settings:read", "admin:auth.providers:read"]},
+        {"user": "admin@tailnet", "role": "authz-admin", "context": "admin", "scopes": ["admin:dashboard:read", "admin:app:update", "admin:auth.settings:read", "admin:auth.settings:update", "admin:auth.providers:read", "admin:auth.providers:update", "admin:authz.roles:read", "admin:authz.roles:update", "admin:authz.scopes:read", "admin:authz.policies:read", "admin:authz.policies:update", "admin:authz.relations:read", "admin:authz.relations:update"]},
     ],
     "auth_config": {
         "environment": "development",
@@ -84,6 +93,15 @@ state = {
         "google_oauth_redirect_url": "https://tailnet-demo.local/auth/google/callback",
         "totp_auth_enabled": True,
         "jwt_secret": "configured-secret",
+        "auth0_domain": "demo.auth0.example",
+        "auth0_client_id": "auth0-demo-client",
+        "auth0_client_secret": "configured-secret",
+        "auth0_callback_url": "http://127.0.0.1:18080/auth/auth0/callback",
+        "entra_tenant_id": "common",
+        "entra_client_id": "entra-demo-client",
+        "scalekit_environment_url": "https://demo.scalekit.com",
+        "scalekit_client_id": "scalekit-demo-client",
+        "scalekit_client_secret": "configured-secret",
     },
     "attribute_policies": [
         {
@@ -258,7 +276,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_html(page("Workflow Tailnet Demo Login", f"""
               <section class="card login-shell">
                 <h1>Sign in</h1>
-                <p>Use <code>admin@tailnet</code>/<code>admin</code>, <code>readonly-admin@tailnet</code>/<code>readonly</code>, or <code>app-user@tailnet</code>/<code>user</code>.</p>
+                <p>Use <code>admin@tailnet</code>/<code>admin</code>, <code>provider-admin@tailnet</code>/<code>provider</code>, <code>readonly-admin@tailnet</code>/<code>readonly</code>, or <code>app-user@tailnet</code>/<code>user</code>.</p>
                 <form method="post" action="/login">
                   <input type="hidden" name="next" value="{escape(next_token)}" />
                   <input name="email" type="email" placeholder="Email" required />
@@ -482,6 +500,14 @@ class Handler(BaseHTTPRequestHandler):
                 return
             self.send_json(auth_admin_describe_output())
             return
+        if path in {"/api/admin/auth/providers", "/api/admin/auth/catalog"}:
+            if not self.require_scope("admin:auth.providers:read"):
+                return
+            catalog = auth_provider_catalog_output()
+            if path == "/api/admin/auth/catalog":
+                catalog = {"provider_catalog": catalog, "auth_admin": auth_admin_describe_output()}
+            self.send_json(catalog)
+            return
         if path == "/api/admin/contributions":
             if not self.require_scope("admin:dashboard:read"):
                 return
@@ -494,7 +520,7 @@ class Handler(BaseHTTPRequestHandler):
             with state_lock:
                 flag = state["flag"]
                 requests = list(state["requests"])
-            self.send_json({"app": "workflow-tailnet-admin-demo", "uptimeSeconds": round(time.time() - started_at, 1), "featureFlag": flag, "requests": requests, "admin": {"auth": auth_admin_capabilities(), "authz": provider_capabilities(), "views": ["auth", "authz", "application", "audit"], "declarations": authz_declarations()}})
+            self.send_json({"app": "workflow-tailnet-admin-demo", "uptimeSeconds": round(time.time() - started_at, 1), "featureFlag": flag, "requests": requests, "admin": {"auth": auth_admin_capabilities(), "auth_provider_catalog": auth_provider_catalog_output(), "authz": provider_capabilities(), "views": ["auth", "authz", "application", "audit"], "declarations": authz_declarations()}})
             return
         self.send_error(HTTPStatus.NOT_FOUND)
 
@@ -572,6 +598,21 @@ class Handler(BaseHTTPRequestHandler):
                     self.send_html(page("Invalid Auth Settings", f"<h1>Invalid Auth Settings</h1><p class='error'>{escape(message)}</p><p><a href='/admin/auth'>Back to authentication</a></p>", principal), HTTPStatus.BAD_REQUEST)
                 return
             self.send_json(result, HTTPStatus.OK if result["valid"] else HTTPStatus.BAD_REQUEST)
+            return
+        if path == "/api/admin/auth/providers/config":
+            if not self.require_scope("admin:auth.providers:update"):
+                return
+            payload = self.json_payload(form)
+            result = auth_provider_config_validate(payload)
+            if not result["valid"]:
+                self.send_json(result, HTTPStatus.BAD_REQUEST)
+                return
+            with state_lock:
+                state["auth_config"].update(result["accepted_config"])
+                for field in result["secret_fields"]:
+                    state["auth_config"][field] = "configured-secret"
+                state["audit"].append({"event": "auth.provider_config.updated", "actor": principal})
+            self.send_json(result)
             return
         if path == "/admin/authz/abac/upsert":
             if not self.require_scope("admin:authz.policies:update", html=True):
@@ -865,8 +906,132 @@ def auth_admin_capabilities():
     return {
         "module": "workflow-plugin-auth",
         "provider": "workflow-plugin-auth admin-config-contract",
-        "capabilities": ["describe_config", "validate_config_patch", "secret_redaction"],
+        "capabilities": ["describe_config", "provider_catalog", "validate_config_patch", "secret_redaction"],
         "health": "ok",
+    }
+
+
+def auth_provider_catalog_output():
+    providers = auth_provider_descriptors()
+    return {
+        "contract": "workflow.plugins.auth.v1.AuthProviderCatalogOutput",
+        "provider_count": len(providers),
+        "providers": providers,
+        "source": "workflow-plugin-auth provider descriptor catalog",
+    }
+
+
+def auth_provider_descriptors():
+    return [
+        provider_descriptor(
+            "local-auth",
+            "Local authentication",
+            "workflow-plugin-auth",
+            "v0.2.11",
+            ["authentication_method"],
+            [
+                capability_descriptor("passkey", "Passkeys", "authentication_method", ["admin:auth.settings:read"], ["admin:auth.settings:update"], [
+                    provider_field("webauthn_rp_id", "Passkey relying party ID", "text", "Domain used to scope passkey credentials.", "Use the effective application host.", False, True),
+                    provider_field("webauthn_origin", "Passkey origin", "url", "Origin that WebAuthn challenges must be created for.", "HTTPS is required outside localhost development.", False, True),
+                ]),
+                capability_descriptor("password", "Password login", "authentication_method", ["admin:auth.settings:read"], ["admin:auth.settings:update"], [
+                    provider_field("password_auth_enabled", "Password login", "toggle", "Allows password sign-in outside production.", "Production policy blocks password login even when enabled.", False, False),
+                ]),
+            ],
+        ),
+        provider_descriptor("generic-oidc", "Generic OIDC", "workflow-plugin-sso", "v0.1.6", ["oauth2_oidc"], [oidc_capability("generic_oidc", "Generic OIDC", [
+            provider_field("generic_oidc_issuer_url", "Issuer URL", "url", "OIDC issuer discovery URL.", "Use the issuer from the provider metadata.", False, True),
+            provider_field("generic_oidc_client_id", "Client ID", "text", "OIDC client identifier.", "Pair with a write-only client secret.", False, True),
+            provider_field("generic_oidc_client_secret", "Client secret", "secret", "OIDC client secret.", "Write-only. Leave blank to keep a configured value.", True, True),
+            provider_field("generic_oidc_scopes", "OIDC scopes", "select", "Scopes requested during authorization.", "Choose only scopes required by the app.", False, True, [
+                {"value": "openid profile email", "label": "openid profile email"},
+                {"value": "openid profile email groups", "label": "openid profile email groups"},
+            ]),
+        ])]),
+        provider_descriptor("okta", "Okta", "workflow-plugin-okta", "v0.2.4", ["identity_management", "oauth2_oidc", "enterprise_sso", "directory_sync"], [oidc_capability("okta_oidc", "Okta OIDC", [
+            provider_field("okta_org_url", "Okta org URL", "url", "Okta organization base URL.", "Example: https://dev-123456.okta.com", False, True),
+            provider_field("okta_client_id", "Client ID", "text", "Okta OIDC client identifier.", "Use a dedicated app integration.", False, True),
+            provider_field("okta_client_secret", "Client secret", "secret", "Okta OIDC client secret.", "Write-only. Store in Workflow secrets.", True, True),
+        ])]),
+        provider_descriptor("auth0", "Auth0", "workflow-plugin-auth0", "v0.1.0", ["identity_management", "oauth2_oidc"], [oidc_capability("auth0_oidc", "Auth0 OIDC", [
+            provider_field("auth0_domain", "Auth0 domain", "text", "Auth0 tenant domain.", "Example: example.us.auth0.com", False, True),
+            provider_field("auth0_client_id", "Auth0 client ID", "text", "Auth0 application client identifier.", "Use Authorization Code with PKCE.", False, True),
+            provider_field("auth0_client_secret", "Auth0 client secret", "secret", "Auth0 application client secret.", "Write-only. Leave blank to keep a configured secret.", True, True),
+            provider_field("auth0_callback_url", "Auth0 callback URL", "url", "Callback URL registered with Auth0.", "Must exactly match the Auth0 application callback.", False, True),
+        ])]),
+        provider_descriptor("entra", "Microsoft Entra ID", "workflow-plugin-entra", "v0.1.0", ["identity_management", "oauth2_oidc", "enterprise_sso", "directory_sync"], [oidc_capability("entra_oidc", "Entra OIDC", [
+            provider_field("entra_tenant_id", "Tenant ID", "text", "Microsoft tenant ID or common endpoint.", "Use a tenant-specific ID for production.", False, True),
+            provider_field("entra_client_id", "Application client ID", "text", "Microsoft app registration client ID.", "Use a dedicated app registration.", False, True),
+            provider_field("entra_client_secret", "Application client secret", "secret", "Microsoft app client secret.", "Write-only. Prefer certificate auth where supported.", True, True),
+        ])]),
+        provider_descriptor("ory-kratos", "Ory Kratos", "workflow-plugin-ory-kratos", "v0.1.0", ["identity_management", "authentication_method"], [
+            capability_descriptor("kratos_identity", "Identity management", "identity_management", ["admin:auth.providers:read"], ["admin:auth.providers:update"], [
+                provider_field("kratos_admin_url", "Admin URL", "url", "Kratos admin API URL.", "Keep this server-side only.", False, True),
+                provider_field("kratos_session_cookie_name", "Session cookie", "text", "Kratos session cookie name.", "Used by application middleware.", False, False),
+            ]),
+        ]),
+        provider_descriptor("ory-hydra", "Ory Hydra", "workflow-plugin-ory-hydra", "v0.1.0", ["oauth2_oidc"], [oidc_capability("hydra_oauth2", "Hydra OAuth2/OIDC", [
+            provider_field("hydra_admin_url", "Hydra admin URL", "url", "Hydra admin API URL.", "Keep this server-side only.", False, True),
+            provider_field("hydra_public_issuer_url", "Issuer URL", "url", "Hydra public issuer URL.", "Used for token validation.", False, True),
+        ])]),
+        provider_descriptor("ory-polis", "Ory Polis", "workflow-plugin-ory-polis", "v0.1.0", ["enterprise_sso", "directory_sync"], [
+            capability_descriptor("polis_enterprise_sso", "Enterprise SSO", "enterprise_sso", ["admin:auth.providers:read"], ["admin:auth.providers:update"], [
+                provider_field("polis_api_url", "Polis API URL", "url", "Polis API base URL.", "Use the internal administration URL.", False, True),
+                provider_field("polis_api_token", "Polis API token", "secret", "Polis API token.", "Write-only. Store in Workflow secrets.", True, True),
+            ]),
+        ]),
+        provider_descriptor("scalekit", "Scalekit", "workflow-plugin-scalekit", "v0.1.0", ["enterprise_sso", "directory_sync"], [
+            capability_descriptor("scalekit_connections", "SSO connections", "enterprise_sso", ["admin:auth.providers:read"], ["admin:auth.providers:update"], [
+                provider_field("scalekit_environment_url", "Environment URL", "url", "Scalekit environment URL.", "Use the value from Scalekit API configuration.", False, True),
+                provider_field("scalekit_client_id", "Client ID", "text", "Scalekit environment client ID.", "Pair with the matching client secret.", False, True),
+                provider_field("scalekit_client_secret", "Client secret", "secret", "Scalekit environment client secret.", "Write-only. Store in Workflow secrets.", True, True),
+            ]),
+        ]),
+    ]
+
+
+def provider_descriptor(provider_id, label, implementation, version, categories, capabilities):
+    return {
+        "id": provider_id,
+        "label": label,
+        "description": f"{label} descriptor exposed by {implementation}.",
+        "categories": categories,
+        "implementation": implementation,
+        "version": version,
+        "docs_url": f"https://github.com/GoCodeAlone/{implementation}",
+        "support_level": "management",
+        "capabilities": capabilities,
+    }
+
+
+def oidc_capability(key, label, fields):
+    return capability_descriptor(key, label, "oauth2_oidc", ["admin:auth.providers:read"], ["admin:auth.providers:update"], fields)
+
+
+def capability_descriptor(key, label, category, read_scopes, write_scopes, fields):
+    return {
+        "key": key,
+        "label": label,
+        "category": category,
+        "description": f"{label} configuration and management contract.",
+        "supported": True,
+        "app_scopes": [],
+        "admin_read_scopes": read_scopes,
+        "admin_write_scopes": write_scopes,
+        "config_fields": fields,
+    }
+
+
+def provider_field(key, label, input_type, description, help_text, secret, required, options=None):
+    return {
+        "key": key,
+        "label": label,
+        "input_type": input_type,
+        "description": description,
+        "help_text": help_text,
+        "secret": secret,
+        "required": required,
+        "options": options or [],
     }
 
 
@@ -880,6 +1045,7 @@ def auth_admin_describe_output():
         "methods_policy": policy,
         "warnings": auth_admin_warnings(config, policy),
         "secret_fields": auth_admin_secret_fields(config),
+        "provider_catalog": auth_provider_catalog_output(),
     }
 
 
@@ -897,6 +1063,13 @@ def render_auth_admin_control(control, effective_config):
     elif control["input_type"] == "secret":
         placeholder = "Configured - leave blank to keep" if control.get("configured") else "Enter secret value"
         field = f"<input aria-label='{label}' title='{title}' type='password' name='{escape(key)}' placeholder='{escape(placeholder)}'{disabled} />"
+    elif control["input_type"] == "select":
+        selected_value = str(effective_config.get(key, "") or "")
+        options = "".join(
+            f"<option value='{escape(option['value'])}'{' selected' if option['value'] == selected_value else ''}>{escape(option.get('label') or option['value'])}</option>"
+            for option in control.get("options", [])
+        )
+        field = f"<select aria-label='{label}' title='{title}' name='{escape(key)}'{disabled}>{options}</select>"
     else:
         value = "" if control.get("secret") else str(effective_config.get(key, "") or "")
         input_type = "url" if control["input_type"] == "url" else "text"
@@ -936,6 +1109,48 @@ def auth_admin_validate_output(desired_config, require_primary_method=True):
     }
 
 
+def auth_provider_config_validate(payload):
+    if not isinstance(payload, dict):
+        return {"valid": False, "errors": [auth_admin_diagnostic("payload", "error", "provider config must be an object")], "accepted_config": {}, "secret_fields": []}
+    provider_id = str(payload.get("provider_id", "") or "").strip()
+    desired_config = payload.get("desired_config", {})
+    if not isinstance(desired_config, dict):
+        return {"valid": False, "errors": [auth_admin_diagnostic("desired_config", "error", "desired_config must be an object")], "accepted_config": {}, "secret_fields": []}
+    providers = {provider["id"]: provider for provider in auth_provider_descriptors()}
+    provider = providers.get(provider_id)
+    if not provider:
+        return {"valid": False, "errors": [auth_admin_diagnostic("provider_id", "error", "provider_id must come from the provider catalog")], "accepted_config": {}, "secret_fields": []}
+    allowed_fields = {}
+    required_fields = set()
+    secret_fields = set()
+    for capability in provider.get("capabilities", []):
+        for field in capability.get("config_fields", []):
+            allowed_fields[field["key"]] = field
+            if field.get("required"):
+                required_fields.add(field["key"])
+            if field.get("secret"):
+                secret_fields.add(field["key"])
+    errors = []
+    for key in desired_config:
+        if key not in allowed_fields:
+            errors.append(auth_admin_diagnostic(key, "error", f"{key} is not declared for provider {provider_id}"))
+    with state_lock:
+        merged = dict(state["auth_config"])
+    merged.update(desired_config)
+    for key in sorted(required_fields):
+        if not auth_admin_present(merged, key):
+            errors.append(auth_admin_diagnostic(key, "error", f"{key} is required for provider {provider_id}"))
+    accepted = auth_admin_sanitize_config({key: value for key, value in desired_config.items() if key in allowed_fields and key not in secret_fields})
+    submitted_secrets = sorted(key for key in desired_config if key in secret_fields and auth_admin_present(desired_config, key))
+    return {
+        "valid": not errors,
+        "provider_id": provider_id,
+        "accepted_config": accepted,
+        "errors": errors,
+        "secret_fields": submitted_secrets,
+    }
+
+
 def auth_admin_groups(config):
     groups = [
         {
@@ -969,8 +1184,8 @@ def auth_admin_groups(config):
         },
         {
             "key": "oauth_providers",
-            "label": "OAuth providers",
-            "description": "External identity providers available to auth routes.",
+            "label": "Provider catalog",
+            "description": "External identity and enterprise SSO providers rendered from registered plugin descriptors.",
             "controls": auth_admin_oauth_controls(config),
         },
     ]
@@ -981,15 +1196,17 @@ def auth_admin_groups(config):
 
 
 def auth_admin_oauth_controls(config):
+    descriptors = auth_provider_descriptors()
     controls = [
-        auth_admin_control(config, "auth_routes_enabled", "Auth routes", "toggle", "Enables HTTP auth routes used by OAuth callback flows.", "OAuth login requires auth routes before any provider can become login-ready."),
+        auth_admin_control(config, "auth_routes_enabled", "Auth routes", "toggle", "Enables HTTP auth routes used by OAuth callback flows.", "OAuth login requires auth routes before any OIDC provider can become login-ready."),
+        auth_admin_control_with_options(config, "active_auth_provider", "Active login provider", "select", "Provider selected from the merged descriptor catalog.", "Choices are registered by provider plugins, not embedded in the UI.", [{"value": provider["id"], "label": f"{provider['label']} ({provider['implementation']})"} for provider in descriptors]),
     ]
-    for provider, label in [("google", "Google"), ("facebook", "Facebook"), ("instagram", "Instagram"), ("x", "X")]:
-        disabled = auth_admin_provider_disabled_reason(provider)
-        controls.append(auth_admin_control(config, f"{provider}_oauth_client_id", f"{label} client ID", "text", f"OAuth client identifier issued by {label}.", "Pair with the matching client secret and redirect URL.", disabled_reason=disabled))
-        controls.append(auth_admin_control(config, f"{provider}_oauth_client_secret", f"{label} client secret", "secret", f"OAuth client secret issued by {label}.", "Write-only. Leave blank to keep an existing configured value.", disabled_reason=disabled))
-        if provider in {"google", "facebook"}:
-            controls.append(auth_admin_control(config, f"{provider}_oauth_redirect_url", f"{label} redirect URL", "url", f"Callback URL registered with {label}.", "Must be HTTPS and match the provider application settings.", disabled_reason=disabled))
+    for provider in descriptors:
+        for capability in provider.get("capabilities", []):
+            if capability.get("category") not in {"oauth2_oidc", "enterprise_sso", "directory_sync", "identity_management"}:
+                continue
+            for field in capability.get("config_fields", []):
+                controls.append(auth_admin_control_from_provider_field(config, provider, capability, field))
     return controls
 
 
@@ -1009,6 +1226,32 @@ def auth_admin_control(config, key, label, input_type, description, help_text, d
         "disabled_reason": disabled_reason,
         "options": [],
     }
+
+
+def auth_admin_control_with_options(config, key, label, input_type, description, help_text, options, disabled_reason=""):
+    control = auth_admin_control(config, key, label, input_type, description, help_text, disabled_reason)
+    control["options"] = options
+    return control
+
+
+def auth_admin_control_from_provider_field(config, provider, capability, field):
+    prefix = provider["label"]
+    control = auth_admin_control(
+        config,
+        field["key"],
+        f"{prefix} {field['label']}",
+        field["input_type"],
+        f"{field['description']} Source: {provider['implementation']} {provider['version']} capability {capability['key']}.",
+        field["help_text"],
+        disabled_reason="" if field.get("required") or field.get("secret") or field.get("options") is not None else "",
+    )
+    control["secret"] = bool(field.get("secret"))
+    control["required"] = bool(field.get("required"))
+    control["configured"] = auth_admin_present(config, field["key"])
+    control["options"] = field.get("options", [])
+    control["provider_id"] = provider["id"]
+    control["capability_key"] = capability["key"]
+    return control
 
 
 def auth_admin_methods_policy(config):

--- a/scenarios/90-admin-tailnet-demo/docker-compose.yml
+++ b/scenarios/90-admin-tailnet-demo/docker-compose.yml
@@ -41,7 +41,21 @@ services:
       - NET_RAW
     devices:
       - /dev/net/tun:/dev/net/tun
-    command: sh -c 'if [ -n "$$TS_AUTHKEY" ]; then tailscaled --state=$$TS_STATE_DIR/tailscaled.state & sleep 2 && tailscale up --authkey=$$TS_AUTHKEY --hostname=$$TS_HOSTNAME && tailscale serve --bg --http=80 http://app:8080 && wait; else echo "TS_AUTHKEY not set; sidecar idle" && sleep infinity; fi'
+    command: >
+      sh -c '
+        tailscaled --state=$$TS_STATE_DIR/tailscaled.state &
+        sleep 2
+        if tailscale status >/dev/null 2>&1; then
+          echo "tailscale sidecar using existing state"
+        elif [ -n "$$TS_AUTHKEY" ]; then
+          tailscale up --authkey=$$TS_AUTHKEY --hostname=$$TS_HOSTNAME
+        else
+          echo "TS_AUTHKEY not set and no reusable state; sidecar idle"
+          wait
+        fi
+        tailscale serve --bg --http=80 http://app:8080 || true
+        wait
+      '
     depends_on:
       app:
         condition: service_healthy

--- a/scenarios/90-admin-tailnet-demo/test/playwright-authz-qa.sh
+++ b/scenarios/90-admin-tailnet-demo/test/playwright-authz-qa.sh
@@ -44,7 +44,7 @@ playwright screenshot \
 
 playwright screenshot \
   --load-storage "$ADMIN_STATE" \
-  --wait-for-selector 'text=Google client secret' \
+  --wait-for-selector 'text=Auth0 client secret' \
   --full-page \
   "$BASE/admin/auth?group=oauth_providers" \
   "$ARTIFACT_DIR/admin-auth-oauth.png" >/dev/null

--- a/scenarios/90-admin-tailnet-demo/test/run.sh
+++ b/scenarios/90-admin-tailnet-demo/test/run.sh
@@ -5,9 +5,10 @@ BASE="${BASE:-http://127.0.0.1:18080}"
 COOKIE_JAR="$(mktemp)"
 FRONTEND_COOKIE="$(mktemp)"
 MALICIOUS_COOKIE="$(mktemp)"
+PROVIDER_COOKIE="$(mktemp)"
 PASS_COUNT=0
 FAIL_COUNT=0
-trap 'rm -f "$COOKIE_JAR" "$FRONTEND_COOKIE" "$MALICIOUS_COOKIE"' EXIT
+trap 'rm -f "$COOKIE_JAR" "$FRONTEND_COOKIE" "$MALICIOUS_COOKIE" "$PROVIDER_COOKIE"' EXIT
 
 pass() { echo "PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
 fail() { echo "FAIL: $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
@@ -20,6 +21,20 @@ contains() {
     pass "$label"
   else
     fail "$label missing pattern: $pattern"
+  fi
+}
+
+validate_provider_config() {
+  local provider="$1"
+  local payload="$2"
+  local label="$3"
+  local response
+  response="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d "$payload" "$BASE/api/admin/auth/providers/config")"
+  contains "$response" '"valid": true' "$label"
+  if grep -q 'rotation-secret' <<<"$response"; then
+    fail "$label should redact submitted provider secrets"
+  else
+    pass "$label redacts submitted provider secrets"
   fi
 }
 
@@ -68,7 +83,11 @@ auth_config="$(curl -b "$COOKIE_JAR" -fsS "$BASE/api/admin/auth/config")"
 contains "$auth_config" '"groups"' "Auth admin config exposes control groups"
 contains "$auth_config" '"config_key": "webauthn_rp_id"' "Auth admin config maps passkey RP ID to real config key"
 contains "$auth_config" '"config_key": "password_auth_enabled"' "Auth admin config maps password toggle to real config key"
-contains "$auth_config" '"Google client secret"' "Auth admin config exposes OAuth secret control metadata"
+contains "$auth_config" '"provider_catalog"' "Auth admin config includes provider catalog"
+contains "$auth_config" '"workflow-plugin-auth0"' "Auth admin config includes Auth0 provider descriptor"
+contains "$auth_config" '"workflow-plugin-entra"' "Auth admin config includes Entra provider descriptor"
+contains "$auth_config" '"workflow-plugin-scalekit"' "Auth admin config includes Scalekit provider descriptor"
+contains "$auth_config" '"Auth0 client secret"' "Auth admin config exposes descriptor-backed OAuth secret control metadata"
 contains "$auth_config" '"secret_fields"' "Auth admin config declares write-only secret fields"
 if grep -q 'configured-secret' <<<"$auth_config"; then
   fail "Auth admin config should not echo configured secret values"
@@ -83,7 +102,7 @@ else
   fail "Auth admin unsafe password expected 400 with diagnostic, got $unsafe_auth_status"
 fi
 
-safe_auth="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d '{"require_primary_method":true,"desired_config":{"environment":"development","webauthn_rp_id":"tailnet-demo.local","webauthn_origin":"http://127.0.0.1:18080","google_oauth_client_secret":"new-secret"}}' "$BASE/api/admin/auth/config/validate")"
+safe_auth="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d '{"require_primary_method":true,"desired_config":{"environment":"development","webauthn_rp_id":"tailnet-demo.local","webauthn_origin":"http://127.0.0.1:18080","auth0_client_secret":"new-secret"}}' "$BASE/api/admin/auth/config/validate")"
 contains "$safe_auth" '"valid": true' "Auth admin accepts safe passkey config patch"
 contains "$safe_auth" '"webauthn_rp_id": "tailnet-demo.local"' "Auth admin returns accepted non-secret config"
 if grep -q 'new-secret' <<<"$safe_auth"; then
@@ -105,8 +124,58 @@ else
   pass "Auth admin UI does not display secret values"
 fi
 auth_oauth_page="$(curl -b "$COOKIE_JAR" -fsS "$BASE/admin/auth?group=oauth_providers")"
-contains "$auth_oauth_page" "Google client secret" "Auth admin OAuth tab labels Google secret"
+contains "$auth_oauth_page" "Provider catalog" "Auth admin provider tab is descriptor-backed"
+contains "$auth_oauth_page" "Active login provider" "Auth admin provider tab uses selectable provider choices"
+contains "$auth_oauth_page" "Auth0 client secret" "Auth admin provider tab labels Auth0 secret"
+contains "$auth_oauth_page" "Scalekit Client secret" "Auth admin provider tab labels Scalekit secret"
 contains "$auth_oauth_page" "Write-only" "Auth admin OAuth tab explains write-only secrets"
+
+provider_catalog="$(curl -b "$COOKIE_JAR" -fsS "$BASE/api/admin/auth/providers")"
+contains "$provider_catalog" '"provider_count": 9' "Provider catalog exposes all composed providers"
+contains "$provider_catalog" '"id": "generic-oidc"' "Provider catalog includes generic OIDC"
+contains "$provider_catalog" '"id": "okta"' "Provider catalog includes Okta"
+contains "$provider_catalog" '"id": "auth0"' "Provider catalog includes Auth0"
+contains "$provider_catalog" '"id": "entra"' "Provider catalog includes Entra"
+contains "$provider_catalog" '"id": "ory-kratos"' "Provider catalog includes Ory Kratos"
+contains "$provider_catalog" '"id": "ory-hydra"' "Provider catalog includes Ory Hydra"
+contains "$provider_catalog" '"id": "ory-polis"' "Provider catalog includes Ory Polis"
+contains "$provider_catalog" '"id": "scalekit"' "Provider catalog includes Scalekit"
+contains "$provider_catalog" '"config_fields"' "Provider catalog exposes lookup-backed field descriptors"
+
+provider_save="$(curl -b "$COOKIE_JAR" -fsS -H 'content-type: application/json' -d '{"provider_id":"auth0","desired_config":{"auth0_domain":"demo.auth0.example","auth0_client_id":"updated-client"}}' "$BASE/api/admin/auth/providers/config")"
+contains "$provider_save" '"valid": true' "Auth admin can save accepted non-secret provider config"
+pass "Provider config save has no submitted secret to echo"
+
+validate_provider_config "local-auth" '{"provider_id":"local-auth","desired_config":{"webauthn_rp_id":"tailnet-demo.local","webauthn_origin":"http://127.0.0.1:18080"}}' "Provider rotation validates local auth"
+validate_provider_config "generic-oidc" '{"provider_id":"generic-oidc","desired_config":{"generic_oidc_issuer_url":"https://issuer.example.test","generic_oidc_client_id":"generic-client","generic_oidc_client_secret":"rotation-secret","generic_oidc_scopes":"openid profile email"}}' "Provider rotation validates generic OIDC"
+validate_provider_config "okta" '{"provider_id":"okta","desired_config":{"okta_org_url":"https://dev-123456.okta.com","okta_client_id":"okta-client","okta_client_secret":"rotation-secret"}}' "Provider rotation validates Okta"
+validate_provider_config "auth0" '{"provider_id":"auth0","desired_config":{"auth0_domain":"demo.auth0.example","auth0_client_id":"auth0-client","auth0_client_secret":"rotation-secret","auth0_callback_url":"http://127.0.0.1:18080/auth/auth0/callback"}}' "Provider rotation validates Auth0"
+validate_provider_config "entra" '{"provider_id":"entra","desired_config":{"entra_tenant_id":"common","entra_client_id":"entra-client","entra_client_secret":"rotation-secret"}}' "Provider rotation validates Entra"
+validate_provider_config "ory-kratos" '{"provider_id":"ory-kratos","desired_config":{"kratos_admin_url":"http://kratos.example.test/admin","kratos_session_cookie_name":"ory_kratos_session"}}' "Provider rotation validates Ory Kratos"
+validate_provider_config "ory-hydra" '{"provider_id":"ory-hydra","desired_config":{"hydra_admin_url":"http://hydra.example.test/admin","hydra_public_issuer_url":"https://hydra.example.test/"}}' "Provider rotation validates Ory Hydra"
+validate_provider_config "ory-polis" '{"provider_id":"ory-polis","desired_config":{"polis_api_url":"https://polis.example.test","polis_api_token":"rotation-secret"}}' "Provider rotation validates Ory Polis"
+validate_provider_config "scalekit" '{"provider_id":"scalekit","desired_config":{"scalekit_environment_url":"https://demo.scalekit.com","scalekit_client_id":"scalekit-client","scalekit_client_secret":"rotation-secret"}}' "Provider rotation validates Scalekit"
+
+invalid_provider_status="$(curl -b "$COOKIE_JAR" -s -o /dev/null -w "%{http_code}" -H 'content-type: application/json' -d '{"provider_id":"unknown","desired_config":{}}' "$BASE/api/admin/auth/providers/config")"
+if [[ "$invalid_provider_status" == "400" ]]; then
+  pass "Unknown provider config fails closed"
+else
+  fail "Unknown provider config expected 400, got $invalid_provider_status"
+fi
+
+curl -s -o /dev/null -c "$PROVIDER_COOKIE" -d 'email=provider-admin@tailnet&password=provider' "$BASE/login"
+provider_page_status="$(curl -b "$PROVIDER_COOKIE" -s -o /dev/null -w "%{http_code}" "$BASE/admin/auth?group=oauth_providers")"
+if [[ "$provider_page_status" == "200" ]]; then
+  pass "Provider admin can view descriptor-backed provider controls"
+else
+  fail "Provider admin expected auth provider page 200, got $provider_page_status"
+fi
+provider_write_status="$(curl -b "$PROVIDER_COOKIE" -s -o /dev/null -w "%{http_code}" -H 'content-type: application/json' -d '{"provider_id":"auth0","desired_config":{"auth0_client_secret":"readonly-secret"}}' "$BASE/api/admin/auth/providers/config")"
+if [[ "$provider_write_status" == "403" ]]; then
+  pass "Provider admin without write scope cannot save secrets"
+else
+  fail "Provider admin secret save expected 403, got $provider_write_status"
+fi
 
 authz="$(curl -b "$COOKIE_JAR" -fsS "$BASE/admin/authz")"
 contains "$authz" "Role and Scope Administration" "Authz UI page renders"

--- a/scenarios/92-infra-admin-demo/README.md
+++ b/scenarios/92-infra-admin-demo/README.md
@@ -21,6 +21,28 @@ proto-driven admin UI surface introduced in workflow PR #791
 | `config/app.yaml` | stub-provider only | Always-pass; deterministic Playwright behavior |
 | `config/app-do-dryrun.yaml` | stub-provider + do-provider (no token) | DO provider fails any live API call; ListProviders + ListTypes still succeed against empty state |
 
+## Auth
+
+PR-1 T15 (commit 47341ff6f) added a route-level auth middleware that gates
+`/api/infra-admin/*` + `/admin/infra-admin/*` + `/api/admin/contributions`.
+The scenario wires it via `auth_module: auth` under `infra-admin.config`
+(mirroring `admin.dashboard.config.auth_module`).
+
+The scenario uses an HS256 baked-in JWT secret for demo simplicity:
+
+```
+hs256_secret: "scenario-92-jwt-secret-do-not-use-in-prod"
+```
+
+**This is test-only.** Both `test/run.sh` and the Playwright spec mint a
+short-lived Bearer token from this secret inline (no external dependency)
+and pass it as `Authorization: Bearer …`. Don't reuse this secret outside
+the scenario.
+
+The new Playwright test `unauthenticated /api/infra-admin/* returns 401`
+is the e2e regression gate that mirrors implementer-1's unit test
+`TestInfraAdmin_ClientCannotSpoofAuthzEvidence`.
+
 ## Running
 
 ```bash

--- a/scenarios/92-infra-admin-demo/README.md
+++ b/scenarios/92-infra-admin-demo/README.md
@@ -31,7 +31,7 @@ The scenario wires it via `auth_module: auth` under `infra-admin.config`
 The scenario uses an HS256 baked-in JWT secret for demo simplicity:
 
 ```
-hs256_secret: "scenario-92-jwt-secret-do-not-use-in-prod"
+secret: "scenario-92-jwt-secret-do-not-use-in-prod"
 ```
 
 **This is test-only.** Both `test/run.sh` and the Playwright spec mint a

--- a/scenarios/92-infra-admin-demo/README.md
+++ b/scenarios/92-infra-admin-demo/README.md
@@ -1,0 +1,47 @@
+# Scenario 92 — Infra Admin (Dynamic, Proto-Driven)
+
+Demonstrates the host-side `infra.admin` workflow module + dynamic
+proto-driven admin UI surface introduced in workflow PR #791
+(`feat/infra-admin-host-module-2026-05-27T1534`).
+
+## What this exercises
+
+- **infra.admin host module** mounts:
+  - `/api/infra-admin/{resources,resources/{name},types,providers,generate-config,audit}` RPC endpoints
+  - `/admin/infra-admin/{resources,resource,new,styles}.{html,js,css}` static asset pages
+- **admin.dashboard plugin** picks up three iframe contributions via the
+  per-pipeline `engine.TriggerWorkflow` registration flow.
+- **wfctl infra admin** CLI mirrors the same surface (parity-tested in
+  PR-1 at `cmd/wfctl/infra_admin_parity_test.go`).
+
+## Two variants
+
+| Variant | iac.provider modules | Notes |
+|---|---|---|
+| `config/app.yaml` | stub-provider only | Always-pass; deterministic Playwright behavior |
+| `config/app-do-dryrun.yaml` | stub-provider + do-provider (no token) | DO provider fails any live API call; ListProviders + ListTypes still succeed against empty state |
+
+## Running
+
+```bash
+# Stub variant
+./seed/seed.sh                           # docker compose up + wait for /healthz
+./test/run.sh                            # PASS/FAIL prefixed test summary + Playwright
+
+# DO dry-run variant
+VARIANT=do-dryrun ./seed/seed.sh
+VARIANT=do-dryrun ./test/run.sh
+```
+
+## Exploratory QA
+
+`test/EXPLORATORY.md` is the template for the post-PR-2 exploratory pass via
+the `playwright-cli` skill. Different from the regression Playwright spec —
+that's the `@playwright/test` spec at
+`workflow-scenarios/e2e/tests/scenario-92-infra-admin.spec.ts`.
+
+## Source plan
+
+- Design: `/Users/jon/workspace/docs/plans/2026-05-27-infra-admin-dynamic-design.md`
+- Plan:   `/Users/jon/workspace/docs/plans/2026-05-27-infra-admin-dynamic.md` §Task 21-25 + §Task 27
+- ADR:    `/Users/jon/workspace/decisions/0002-infra-admin-host-module.md`

--- a/scenarios/92-infra-admin-demo/config/app-do-dryrun.yaml
+++ b/scenarios/92-infra-admin-demo/config/app-do-dryrun.yaml
@@ -1,0 +1,121 @@
+# ============================================================
+# Scenario 92 — Infra Admin (DigitalOcean dry-run variant)
+#
+# Identical to config/app.yaml except adds an iac.provider type=digitalocean
+# alongside the stub provider. No DIGITALOCEAN_TOKEN env var is set, so any
+# live API call would fail — but the admin RPC surface (ListProviders,
+# ListResourceTypes, ListResources against empty state) succeeds without
+# touching the API. Verifies the catalog's region/engine matrix for DO is
+# wired correctly.
+# ============================================================
+
+modules:
+  - name: auth
+    type: auth.jwt
+    config:
+      issuer: "scenario-92"
+      hs256_secret: "scenario-92-jwt-secret-do-not-use-in-prod"
+
+  - name: authz
+    type: authz.casbin
+    config:
+      policy_path: /etc/scenario-92/policy.csv
+
+  - name: security-headers
+    type: http.middleware.securityheaders
+    config:
+      frameOptions: SAMEORIGIN
+      contentSecurityPolicy: >-
+        default-src 'self'; script-src 'self'; style-src 'self';
+        img-src 'self' data:; frame-ancestors 'self'
+
+  - name: http
+    type: http.server
+    config:
+      address: ":8080"
+
+  - name: http-router
+    type: http.router
+    dependsOn: [http]
+
+  - name: admin
+    type: admin.dashboard
+    config:
+      route_prefix: /admin
+      app_name: Scenario 92 — Infra Admin (DO dry-run)
+      auth_module: auth
+      authz_module: authz
+
+  - name: iac-state
+    type: iac.state
+    config:
+      backend: memory
+
+  - name: stub-provider
+    type: iac.provider
+    config:
+      provider: stub
+
+  # No DIGITALOCEAN_TOKEN set — any live API call fails, but admin RPCs
+  # against empty state succeed. Tests the DO branch of the region +
+  # engine catalogs.
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+
+  - name: infra-admin
+    type: infra.admin
+    config:
+      route_prefix:            /api/infra-admin
+      asset_prefix:            /admin/infra-admin
+      state_module:            iac-state
+      http_module:             http
+      security_headers_module: security-headers
+      provider_modules:        [stub-provider, do-provider]
+      access_log_path:         /var/log/infra-admin-audit.jsonl
+
+workflows:
+  http:
+    server: http
+    router: http-router
+    routes: []
+
+pipelines:
+  register-infra-admin-resources:
+    trigger: { type: manual }
+    steps:
+      - name: register
+        type: step.admin_register_contribution
+        config: { module: admin }
+
+  register-infra-admin-resource-detail:
+    trigger: { type: manual }
+    steps:
+      - name: register
+        type: step.admin_register_contribution
+        config: { module: admin }
+
+  register-infra-admin-new-resource:
+    trigger: { type: manual }
+    steps:
+      - name: register
+        type: step.admin_register_contribution
+        config: { module: admin }
+
+  list-admin-contributions:
+    trigger:
+      type: http
+      config:
+        path: /api/admin/contributions
+        method: GET
+    steps:
+      - name: list
+        type: step.admin_list_contributions
+        config: { module: admin }
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            contributions: { _from: "contributions" }

--- a/scenarios/92-infra-admin-demo/config/app-do-dryrun.yaml
+++ b/scenarios/92-infra-admin-demo/config/app-do-dryrun.yaml
@@ -14,7 +14,7 @@ modules:
     type: auth.jwt
     config:
       issuer: "scenario-92"
-      hs256_secret: "scenario-92-jwt-secret-do-not-use-in-prod"
+      secret: "scenario-92-jwt-secret-do-not-use-in-prod"
 
   - name: authz
     type: authz.casbin

--- a/scenarios/92-infra-admin-demo/config/app-do-dryrun.yaml
+++ b/scenarios/92-infra-admin-demo/config/app-do-dryrun.yaml
@@ -71,6 +71,9 @@ modules:
       asset_prefix:            /admin/infra-admin
       state_module:            iac-state
       http_module:             http
+      # auth_module wires T15's route-level auth gate (PR-1 47341ff6f).
+      # See config/app.yaml for the rationale comment.
+      auth_module:             auth
       security_headers_module: security-headers
       provider_modules:        [stub-provider, do-provider]
       access_log_path:         /var/log/infra-admin-audit.jsonl

--- a/scenarios/92-infra-admin-demo/config/app.yaml
+++ b/scenarios/92-infra-admin-demo/config/app.yaml
@@ -20,7 +20,7 @@ modules:
     type: auth.jwt
     config:
       issuer: "scenario-92"
-      hs256_secret: "scenario-92-jwt-secret-do-not-use-in-prod"
+      secret: "scenario-92-jwt-secret-do-not-use-in-prod"
 
   - name: authz
     type: authz.casbin

--- a/scenarios/92-infra-admin-demo/config/app.yaml
+++ b/scenarios/92-infra-admin-demo/config/app.yaml
@@ -69,6 +69,11 @@ modules:
       asset_prefix:            /admin/infra-admin
       state_module:            iac-state
       http_module:             http
+      # auth_module wires T15's route-level auth gate (PR-1 47341ff6f):
+      # every /api/infra-admin/* and /admin/infra-admin/* request must
+      # carry a valid JWT bearer token issued by the named auth module.
+      # Mirrors admin.dashboard's auth_module convention above.
+      auth_module:             auth
       security_headers_module: security-headers
       provider_modules:        [stub-provider]
       access_log_path:         /var/log/infra-admin-audit.jsonl

--- a/scenarios/92-infra-admin-demo/config/app.yaml
+++ b/scenarios/92-infra-admin-demo/config/app.yaml
@@ -1,0 +1,129 @@
+# ============================================================
+# Scenario 92 — Infra Admin (stub variant)
+#
+# Full app YAML mirroring docs/plans/2026-05-27-infra-admin-dynamic-design.md
+# §App Integration. Boots:
+#   - auth.jwt + authz.casbin
+#   - http.middleware.securityheaders (permissive frame-ancestors 'self')
+#   - http.server + http.router
+#   - admin.dashboard (workflow-plugin-admin)
+#   - iac.state (memory) + stub iac.provider
+#   - infra.admin (host-side module) — fires 3 registration pipelines on Start
+#
+# Three single-step pipelines register the iframe contributions via the
+# STRICT_PROTO step.admin_register_contribution. The list-admin-contributions
+# pipeline backs admin shell's GET /api/admin/contributions.
+# ============================================================
+
+modules:
+  - name: auth
+    type: auth.jwt
+    config:
+      issuer: "scenario-92"
+      hs256_secret: "scenario-92-jwt-secret-do-not-use-in-prod"
+
+  - name: authz
+    type: authz.casbin
+    config:
+      policy_path: /etc/scenario-92/policy.csv
+
+  - name: security-headers
+    type: http.middleware.securityheaders
+    config:
+      frameOptions: SAMEORIGIN
+      contentSecurityPolicy: >-
+        default-src 'self'; script-src 'self'; style-src 'self';
+        img-src 'self' data:; frame-ancestors 'self'
+
+  - name: http
+    type: http.server
+    config:
+      address: ":8080"
+
+  - name: http-router
+    type: http.router
+    dependsOn: [http]
+
+  - name: admin
+    type: admin.dashboard
+    config:
+      route_prefix: /admin
+      app_name: Scenario 92 — Infra Admin Demo
+      auth_module: auth
+      authz_module: authz
+
+  - name: iac-state
+    type: iac.state
+    config:
+      backend: memory
+
+  - name: stub-provider
+    type: iac.provider
+    config:
+      provider: stub
+
+  - name: infra-admin
+    type: infra.admin
+    config:
+      route_prefix:            /api/infra-admin
+      asset_prefix:            /admin/infra-admin
+      state_module:            iac-state
+      http_module:             http
+      security_headers_module: security-headers
+      provider_modules:        [stub-provider]
+      access_log_path:         /var/log/infra-admin-audit.jsonl
+
+workflows:
+  http:
+    server: http
+    router: http-router
+    routes: []   # routes mounted by infra.admin module + list-admin-contributions pipeline
+
+pipelines:
+  # Three single-step pipelines fired by infra.admin.Start() via
+  # engine.TriggerWorkflow. Each merges its `data` payload into
+  # PipelineContext.Current; the typed step reads TypedInput from
+  # Current per the STRICT_PROTO RegisterContributionInput shape.
+  register-infra-admin-resources:
+    trigger: { type: manual }
+    steps:
+      - name: register
+        type: step.admin_register_contribution
+        config: { module: admin }
+
+  register-infra-admin-resource-detail:
+    trigger: { type: manual }
+    steps:
+      - name: register
+        type: step.admin_register_contribution
+        config: { module: admin }
+
+  register-infra-admin-new-resource:
+    trigger: { type: manual }
+    steps:
+      - name: register
+        type: step.admin_register_contribution
+        config: { module: admin }
+
+  # HTTP-triggered pipeline the admin shell GETs to enumerate contributions.
+  # Terminating step.json_response with `_from` reference sets the response
+  # body explicitly — step.http_trigger otherwise returns the generic 202
+  # envelope (design cycle-6 Critical #2). Admin shell at
+  # workflow-plugin-admin/internal/ui_dist/index.html:328 reads
+  # `payload.contributions`.
+  list-admin-contributions:
+    trigger:
+      type: http
+      config:
+        path: /api/admin/contributions
+        method: GET
+    steps:
+      - name: list
+        type: step.admin_list_contributions
+        config: { module: admin }
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            contributions: { _from: "contributions" }

--- a/scenarios/92-infra-admin-demo/docker-compose.yml
+++ b/scenarios/92-infra-admin-demo/docker-compose.yml
@@ -20,7 +20,11 @@ services:
       # default like `stub` would point at a non-existent app-stub.yaml.
       # Spec-reviewer F1 on PR-2.
       VARIANT: ${VARIANT:-}
-      JWT_SECRET: scenario-92-jwt-secret-do-not-use-in-prod
+      # NB: no JWT_SECRET env var. The auth.jwt module reads
+      # hs256_secret from the YAML config at config/app{,-do-dryrun}.yaml.
+      # Adding an env var here would create a "which one wins" ambiguity
+      # when someone changes one but not the other. Test + Playwright
+      # JWT minting MUST use the literal hs256_secret from app.yaml.
     ports:
       - "127.0.0.1:18092:8080"
     volumes:

--- a/scenarios/92-infra-admin-demo/docker-compose.yml
+++ b/scenarios/92-infra-admin-demo/docker-compose.yml
@@ -1,0 +1,41 @@
+# ============================================================
+# Scenario 92 — Infra Admin docker-compose
+#
+# Brings up a single workflow-server container with the
+# workflow-plugin-admin plugin baked in (via the pre-built
+# `workflow-admin:scenario-92` image from seed/build.sh).
+#
+# Port 18092 exposed locally so it doesn't collide with other
+# scenarios running concurrently (convention: 180<scenario-id>).
+# ============================================================
+
+services:
+  app:
+    image: workflow-admin:scenario-92
+    container_name: workflow-scenario-92-app
+    environment:
+      VARIANT: ${VARIANT:-stub}
+      JWT_SECRET: scenario-92-jwt-secret-do-not-use-in-prod
+    ports:
+      - "127.0.0.1:18092:8080"
+    volumes:
+      - ./config:/etc/scenario-92:ro
+      - audit-log:/var/log
+    command:
+      - server
+      - "-config"
+      # VARIANT picks between app.yaml (stub) and app-do-dryrun.yaml.
+      # docker compose substitutes ${VARIANT} at compose-up time.
+      - "/etc/scenario-92/app${VARIANT:+-${VARIANT}}.yaml"
+    healthcheck:
+      test:
+        - CMD
+        - sh
+        - -c
+        - "wget -q -O- http://127.0.0.1:8080/healthz || exit 1"
+      interval: 3s
+      timeout: 2s
+      retries: 30
+
+volumes:
+  audit-log:

--- a/scenarios/92-infra-admin-demo/docker-compose.yml
+++ b/scenarios/92-infra-admin-demo/docker-compose.yml
@@ -21,10 +21,10 @@ services:
       # Spec-reviewer F1 on PR-2.
       VARIANT: ${VARIANT:-}
       # NB: no JWT_SECRET env var. The auth.jwt module reads
-      # hs256_secret from the YAML config at config/app{,-do-dryrun}.yaml.
+      # secret from the YAML config at config/app{,-do-dryrun}.yaml.
       # Adding an env var here would create a "which one wins" ambiguity
       # when someone changes one but not the other. Test + Playwright
-      # JWT minting MUST use the literal hs256_secret from app.yaml.
+      # JWT minting MUST use the literal secret from app.yaml.
     ports:
       - "127.0.0.1:18092:8080"
     volumes:

--- a/scenarios/92-infra-admin-demo/docker-compose.yml
+++ b/scenarios/92-infra-admin-demo/docker-compose.yml
@@ -14,7 +14,12 @@ services:
     image: workflow-admin:scenario-92
     container_name: workflow-scenario-92-app
     environment:
-      VARIANT: ${VARIANT:-stub}
+      # VARIANT default empty matches seed.sh — line 16's substitution
+      # `app${VARIANT:+-${VARIANT}}.yaml` produces `app.yaml` when empty,
+      # `app-do-dryrun.yaml` when VARIANT=do-dryrun. Setting a non-empty
+      # default like `stub` would point at a non-existent app-stub.yaml.
+      # Spec-reviewer F1 on PR-2.
+      VARIANT: ${VARIANT:-}
       JWT_SECRET: scenario-92-jwt-secret-do-not-use-in-prod
     ports:
       - "127.0.0.1:18092:8080"
@@ -24,8 +29,6 @@ services:
     command:
       - server
       - "-config"
-      # VARIANT picks between app.yaml (stub) and app-do-dryrun.yaml.
-      # docker compose substitutes ${VARIANT} at compose-up time.
       - "/etc/scenario-92/app${VARIANT:+-${VARIANT}}.yaml"
     healthcheck:
       test:

--- a/scenarios/92-infra-admin-demo/scenario.yaml
+++ b/scenarios/92-infra-admin-demo/scenario.yaml
@@ -1,0 +1,35 @@
+name: Infra Admin (Dynamic, Proto-Driven)
+id: "92-infra-admin-demo"
+category: C
+description: |
+  Boots a workflow server with admin.dashboard + infra.admin host-side module +
+  stub iac.provider. Exercises the typed admin RPC contracts (5 read RPCs +
+  audit) and the new-resource form-builder UI's dependent dropdowns end-to-end.
+
+  Two variants:
+    - app.yaml         — stub iac.provider only (deterministic, always-pass)
+    - app-do-dryrun.yaml — adds an iac.provider type=digitalocean (no token,
+                          fails any live API call; ListProviders + ListTypes
+                          still succeed against empty state)
+
+  v1 is read-only: no PLAN/APPLY/DESTROY/DRIFT-CHECK mutations from the UI.
+  Mutations remain in `wfctl infra apply/destroy/drift` as before.
+
+  Playwright spec at e2e/tests/scenario-92-infra-admin.spec.ts covers:
+    - admin shell registers the 3 infra contributions
+    - resources table populates from pre-seeded state
+    - resource detail view renders typed summary + applied_config + outputs
+    - new-resource form-builder: type dropdown, dependent provider→region
+      dropdowns, --field submission, YAML output preview
+components:
+  - workflow (host-side infra.admin module)
+  - workflow-plugin-admin
+  - iac.state (memory)
+  - iac.provider (stub)
+status: testable
+tags:
+  - admin
+  - iac
+  - proto-contracts
+  - dropdown-forms
+  - playwright

--- a/scenarios/92-infra-admin-demo/seed/seed.sh
+++ b/scenarios/92-infra-admin-demo/seed/seed.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Scenario 92 — Infra Admin demo seed
+#
+# Builds the workflow-admin:scenario-92 docker image (if not present) and
+# brings up the docker-compose stack. infra.admin.Start() fires three
+# registration pipelines automatically via engine.TriggerWorkflow when
+# the host boots — no third curl needed.
+#
+# Variants:
+#   ./seed.sh                       # config/app.yaml (stub)
+#   VARIANT=do-dryrun ./seed.sh     # config/app-do-dryrun.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCENARIO_DIR="$(dirname "$SCRIPT_DIR")"
+SCENARIOS_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+WORKFLOW_REPO="${WORKFLOW_REPO:-$(cd "$SCENARIOS_ROOT/.." && pwd)/workflow}"
+PLUGIN_ADMIN_REPO="${PLUGIN_ADMIN_REPO:-$(cd "$SCENARIOS_ROOT/.." && pwd)/workflow-plugin-admin}"
+IMAGE_TAG="${IMAGE_TAG:-workflow-admin:scenario-92}"
+VARIANT="${VARIANT:-}"   # "" → app.yaml; "do-dryrun" → app-do-dryrun.yaml
+
+echo ""
+echo "=== Scenario 92 seed ==="
+echo "  WORKFLOW_REPO=$WORKFLOW_REPO"
+echo "  PLUGIN_ADMIN_REPO=$PLUGIN_ADMIN_REPO"
+echo "  IMAGE_TAG=$IMAGE_TAG"
+echo "  VARIANT=${VARIANT:-stub}"
+echo ""
+
+# --- Build workflow server + admin plugin binaries ----------------------------
+# We build native (host-OS) binaries and inject them via a thin Dockerfile.
+# This avoids re-baking the whole Go toolchain into the scenario image and
+# matches the convention used by Dockerfile.admin at the repo root.
+
+BUILD_DIR="$SCENARIO_DIR/.build"
+mkdir -p "$BUILD_DIR/plugins/workflow-plugin-admin"
+
+if [ ! -f "$WORKFLOW_REPO/go.mod" ]; then
+    echo "ERROR: WORKFLOW_REPO=$WORKFLOW_REPO is not a Go module checkout" >&2
+    exit 1
+fi
+if [ ! -f "$PLUGIN_ADMIN_REPO/go.mod" ]; then
+    echo "ERROR: PLUGIN_ADMIN_REPO=$PLUGIN_ADMIN_REPO is not a Go module checkout" >&2
+    exit 1
+fi
+
+echo "Building workflow server binary..."
+(cd "$WORKFLOW_REPO" && GOWORK=off GOOS=linux GOARCH=amd64 \
+    go build -o "$BUILD_DIR/server" ./cmd/server)
+
+echo "Building workflow-plugin-admin binary..."
+(cd "$PLUGIN_ADMIN_REPO" && GOWORK=off GOOS=linux GOARCH=amd64 \
+    go build -o "$BUILD_DIR/plugins/workflow-plugin-admin/workflow-plugin-admin" \
+    ./cmd/workflow-plugin-admin)
+cp "$PLUGIN_ADMIN_REPO/plugin.json" "$BUILD_DIR/plugins/workflow-plugin-admin/plugin.json"
+
+# --- Build the scenario image -------------------------------------------------
+
+cat > "$BUILD_DIR/Dockerfile" <<'EOF'
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY server /usr/local/bin/server
+COPY plugins/ /data/plugins/
+USER nonroot
+ENV WFCTL_PLUGIN_DIR=/data/plugins
+ENTRYPOINT ["/usr/local/bin/server"]
+EOF
+
+echo "Building $IMAGE_TAG..."
+docker build -t "$IMAGE_TAG" "$BUILD_DIR"
+
+# --- Bring up the stack -------------------------------------------------------
+
+cd "$SCENARIO_DIR"
+export VARIANT
+docker compose down --remove-orphans 2>/dev/null || true
+docker compose up -d
+
+echo "Waiting for /healthz ..."
+for i in $(seq 1 60); do
+    if curl -fs http://127.0.0.1:18092/healthz >/dev/null 2>&1; then
+        echo "Stack ready at http://127.0.0.1:18092 (took ${i}s)"
+        echo "infra.admin contributions auto-registered by infra.admin.Start()."
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "ERROR: /healthz never became ready" >&2
+docker compose logs --tail=80 app >&2
+exit 1

--- a/scenarios/92-infra-admin-demo/test/EXPLORATORY.md
+++ b/scenarios/92-infra-admin-demo/test/EXPLORATORY.md
@@ -1,0 +1,92 @@
+# Scenario 92 — Exploratory QA Template
+
+Filled out by the post-PR-2 exploratory-QA agent via the `playwright-cli`
+skill in headless mode with isolated browser sessions per workspace
+convention. This is **separate** from the regression Playwright spec
+at `workflow-scenarios/e2e/tests/scenario-92-infra-admin.spec.ts`.
+
+## Setup
+
+| Field | Value |
+|---|---|
+| Base URL | http://127.0.0.1:18092 |
+| Variant | stub (default) or do-dryrun |
+| Browser | Chromium headless |
+| Capture dir | `test/screenshots/` |
+
+Run `./seed/seed.sh` first; abort if `/healthz` doesn't come up.
+
+## Pages walked
+
+- [ ] `/admin/infra-admin/resources.html`
+- [ ] `/admin/infra-admin/resource.html?name=<seeded>`
+- [ ] `/admin/infra-admin/new.html`
+
+Per page, capture: visible navigation, error region empty, filters
+render, primary content loaded without console errors.
+
+## Dropdown population per type (new.html)
+
+For each typed module, open new.html, select the type, screenshot the
+form, assert each dropdown is populated from the correct enum source.
+
+| Type | provider dropdown | region dropdown | engine / size dropdown | screenshot |
+|---|---|---|---|---|
+| infra.vpc                |  |  | n/a |  |
+| infra.container_service  |  |  | n/a |  |
+| infra.k8s_cluster        |  |  | size: enum_dynamic / sizes |  |
+| infra.database           |  |  | engine: enum_dynamic / engines (depends_on provider) |  |
+| infra.cache              |  |  | engine: enum (redis/memcached/valkey) |  |
+| infra.load_balancer      |  |  | n/a |  |
+| infra.dns                |  | n/a (region omitted by design) | n/a |  |
+| infra.registry           |  |  | n/a |  |
+| infra.api_gateway        |  |  | n/a |  |
+| infra.firewall           |  |  | n/a |  |
+| infra.iam_role           |  |  | n/a |  |
+| infra.storage            |  |  | n/a |  |
+| infra.certificate        |  |  | n/a |  |
+
+## Form submission per type
+
+For 4 representative types (vpc, database, container_service, k8s_cluster),
+fill the form with valid values and submit. Capture the generated YAML output.
+
+| Type | Filled values | YAML output snippet | Pass/Fail |
+|---|---|---|---|
+| infra.vpc                | provider=stub-provider region=test-region-1 cidr=10.0.0.0/16 |  |  |
+| infra.database           | provider=stub-provider region=test-region-1 engine=postgres size=m storage_gb=20 version=15.5 multi_az=false |  |  |
+| infra.container_service  | provider=stub-provider region=test-region-1 image=nginx:latest replicas=2 ports=[80,443] |  |  |
+| infra.k8s_cluster        | provider=stub-provider region=test-region-1 version=1.30 node_count=3 node_size=m |  |  |
+
+## CSP / security observations
+
+- [ ] No inline scripts on any asset page (Network DevTools)
+- [ ] Cookies have SameSite + Secure attrs where applicable
+- [ ] `frame-ancestors 'self'` header on every asset response
+- [ ] CSP `script-src 'self'` only (no unsafe-inline)
+
+## Screenshots index
+
+Capture as `test/screenshots/scenario-92-<page>-<note>.png`.
+
+- `resources-empty.png` — pre-seed state
+- `resources-populated.png` — after seed.sh
+- `resource-detail-vpc.png`
+- `new-form-vpc.png`
+- `new-form-database.png`
+- `new-form-container-service.png`
+- `new-form-k8s.png`
+- `yaml-output-vpc.png`
+
+## Issues found (file as workflow#xxx)
+
+| # | Severity | Description | File at |
+|---|---|---|---|
+|   |   |   |   |
+
+## Sign-off
+
+- Agent: _________
+- Date: __________
+- Variant tested: stub / do-dryrun / both
+- Outcome: pass / fail (with linked follow-ups above)

--- a/scenarios/92-infra-admin-demo/test/run.sh
+++ b/scenarios/92-infra-admin-demo/test/run.sh
@@ -74,7 +74,7 @@ fi
 # --- Mint HS256 JWT matching the scenario's auth.jwt module ---
 # Per PR-1 T15 auth gate (47341ff6f), /api/admin/contributions +
 # /api/infra-admin/* + /admin/infra-admin/* require a Bearer token
-# signed by the scenario's HS256 secret (config/app.yaml::auth.config.hs256_secret).
+# signed by the scenario's HS256 secret (config/app.yaml::auth.config.secret).
 # We mint a long-lived token inline so the smoke checks don't need
 # an external dependency. The token is test-only — the secret is
 # the literal "scenario-92-jwt-secret-do-not-use-in-prod".

--- a/scenarios/92-infra-admin-demo/test/run.sh
+++ b/scenarios/92-infra-admin-demo/test/run.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Scenario 92 — Infra Admin test runner
+#
+# Runs:
+#   1. curl smoke checks against the live docker-compose stack
+#      (config-validation + RPC endpoints)
+#   2. wfctl infra admin CLI parity smoke (per plan §CLI end-to-end smoke)
+#   3. Playwright regression spec from the central e2e harness
+#
+# Assumes seed.sh has already brought up the stack.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCENARIO_DIR="$(dirname "$SCRIPT_DIR")"
+SCENARIOS_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+WORKFLOW_REPO="${WORKFLOW_REPO:-$(cd "$SCENARIOS_ROOT/.." && pwd)/workflow}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:18092}"
+SCENARIO="92-infra-admin-demo"
+VARIANT="${VARIANT:-}"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "SKIP: $1"; SKIP=$((SKIP + 1)); }
+
+echo ""
+echo "=== Scenario $SCENARIO (variant=${VARIANT:-stub}) ==="
+echo ""
+
+# --- Locate wfctl binary -----------------------------------------------------
+
+WFCTL=""
+for candidate in \
+    "$(which wfctl 2>/dev/null)" \
+    "$WORKFLOW_REPO/wfctl" \
+    "$WORKFLOW_REPO/bin/wfctl" \
+    "${WFCTL_BIN:-}"; do
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+        WFCTL="$candidate"
+        break
+    fi
+done
+
+if [ -z "$WFCTL" ]; then
+    echo "Building wfctl from $WORKFLOW_REPO..."
+    (cd "$WORKFLOW_REPO" && GOWORK=off go build -o wfctl ./cmd/wfctl)
+    WFCTL="$WORKFLOW_REPO/wfctl"
+fi
+
+CFG_NAME="app.yaml"
+[ -n "$VARIANT" ] && CFG_NAME="app-${VARIANT}.yaml"
+CFG_LOCAL="$SCENARIO_DIR/config/$CFG_NAME"
+
+# --- Phase 1: config validation ----------------------------------------------
+
+if "$WFCTL" validate "$CFG_LOCAL" >/dev/null 2>&1; then
+    pass "wfctl validate accepts $CFG_NAME"
+else
+    fail "wfctl validate rejected $CFG_NAME"
+fi
+
+# --- Phase 2: HTTP smoke against live stack ----------------------------------
+
+if curl -fs "$BASE_URL/healthz" >/dev/null 2>&1; then
+    pass "GET /healthz returns 200"
+else
+    fail "GET /healthz failed (is seed.sh up?)"
+fi
+
+# Admin contributions endpoint (auto-populated by infra.admin.Start()).
+CONTRIB_RESPONSE=$(curl -fs "$BASE_URL/api/admin/contributions" 2>&1 || true)
+if echo "$CONTRIB_RESPONSE" | grep -q "infra.resources"; then
+    pass "GET /api/admin/contributions includes infra.resources"
+else
+    fail "GET /api/admin/contributions missing infra.resources (got: $(echo "$CONTRIB_RESPONSE" | head -c 200))"
+fi
+if echo "$CONTRIB_RESPONSE" | grep -q "infra.new"; then
+    pass "GET /api/admin/contributions includes infra.new"
+else
+    fail "GET /api/admin/contributions missing infra.new"
+fi
+
+# Read-side typed RPCs: POST returns 200 with the typed payload.
+RPC_BODY='{"evidence":{"authz_checked":true,"authz_allowed":true}}'
+for rpc in resources types providers; do
+    code=$(curl -s -o /tmp/scenario-92-$rpc.json -w '%{http_code}' \
+        -X POST -H 'Content-Type: application/json' \
+        -d "$RPC_BODY" "$BASE_URL/api/infra-admin/$rpc" || echo "000")
+    if [ "$code" = "200" ]; then
+        pass "POST /api/infra-admin/$rpc returns 200"
+    else
+        fail "POST /api/infra-admin/$rpc returned $code"
+    fi
+done
+
+# Asset page reachable (proves embed.FS + middleware wiring).
+if curl -fs "$BASE_URL/admin/infra-admin/new.html" | grep -q '<title>Draft New Infra Resource</title>'; then
+    pass "GET /admin/infra-admin/new.html serves the form-builder page"
+else
+    fail "new.html not served correctly"
+fi
+
+# --- Phase 3: wfctl infra admin CLI smoke (per plan §CLI end-to-end smoke) ---
+
+for cmd in "list-resources" "list-types" "list-providers"; do
+    out_file="/tmp/scenario-92-wfctl-$cmd.json"
+    if ! "$WFCTL" infra admin $cmd -c "$CFG_LOCAL" --format json > "$out_file" 2>/dev/null; then
+        fail "wfctl infra admin $cmd returned non-zero"
+        continue
+    fi
+    if command -v jq >/dev/null 2>&1; then
+        if jq -e '.' "$out_file" >/dev/null 2>&1; then
+            pass "wfctl infra admin $cmd output is valid JSON"
+        else
+            fail "wfctl infra admin $cmd output not valid JSON"
+        fi
+    else
+        # Fallback when jq absent: smoke-check braces.
+        if grep -q '{' "$out_file"; then
+            pass "wfctl infra admin $cmd output looks JSON-shaped (jq absent)"
+        else
+            fail "wfctl infra admin $cmd output not JSON-shaped"
+        fi
+    fi
+done
+
+# --- Phase 4: Playwright regression spec from central harness ----------------
+
+PLAYWRIGHT_SPEC="$SCENARIOS_ROOT/e2e/tests/scenario-92-infra-admin.spec.ts"
+if [ -f "$PLAYWRIGHT_SPEC" ]; then
+    if command -v npx >/dev/null 2>&1; then
+        echo ""
+        echo "Running Playwright regression spec..."
+        (cd "$SCENARIOS_ROOT/e2e" && \
+            SCENARIO_URL="$BASE_URL" \
+            npx playwright test scenario-92-infra-admin.spec.ts \
+            --reporter=list 2>&1 | tail -40) \
+            && pass "Playwright scenario-92 spec passed" \
+            || fail "Playwright scenario-92 spec failed (see output above)"
+    else
+        skip "Playwright skipped (npx not installed)"
+    fi
+else
+    fail "Playwright spec not found at $PLAYWRIGHT_SPEC"
+fi
+
+# --- Summary -----------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scenarios/92-infra-admin-demo/test/run.sh
+++ b/scenarios/92-infra-admin-demo/test/run.sh
@@ -71,8 +71,39 @@ else
     fail "GET /healthz failed (is seed.sh up?)"
 fi
 
+# --- Mint HS256 JWT matching the scenario's auth.jwt module ---
+# Per PR-1 T15 auth gate (47341ff6f), /api/admin/contributions +
+# /api/infra-admin/* + /admin/infra-admin/* require a Bearer token
+# signed by the scenario's HS256 secret (config/app.yaml::auth.config.hs256_secret).
+# We mint a long-lived token inline so the smoke checks don't need
+# an external dependency. The token is test-only — the secret is
+# the literal "scenario-92-jwt-secret-do-not-use-in-prod".
+JWT_SECRET='scenario-92-jwt-secret-do-not-use-in-prod'
+NOW=$(date +%s)
+EXP=$((NOW + 3600))
+
+b64url() { openssl base64 -e -A | tr '+/' '-_' | tr -d '='; }
+
+HEADER=$(printf '%s' '{"alg":"HS256","typ":"JWT"}' | b64url)
+PAYLOAD=$(printf '{"iss":"scenario-92","sub":"scenario-92-run","iat":%d,"exp":%d}' "$NOW" "$EXP" | b64url)
+UNSIGNED="${HEADER}.${PAYLOAD}"
+SIGNATURE=$(printf '%s' "$UNSIGNED" | openssl dgst -sha256 -hmac "$JWT_SECRET" -binary | b64url)
+BEARER="${UNSIGNED}.${SIGNATURE}"
+AUTH_HEADER="Authorization: Bearer $BEARER"
+
+# T15 auth-gate regression check: unauthenticated request must 401.
+unauth_code=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"evidence":{"authz_checked":true,"authz_allowed":true}}' \
+    "$BASE_URL/api/infra-admin/resources" || echo "000")
+if [ "$unauth_code" = "401" ]; then
+    pass "POST /api/infra-admin/resources without auth returns 401 (T15 auth gate)"
+else
+    fail "POST /api/infra-admin/resources without auth returned $unauth_code (want 401)"
+fi
+
 # Admin contributions endpoint (auto-populated by infra.admin.Start()).
-CONTRIB_RESPONSE=$(curl -fs "$BASE_URL/api/admin/contributions" 2>&1 || true)
+CONTRIB_RESPONSE=$(curl -fs -H "$AUTH_HEADER" "$BASE_URL/api/admin/contributions" 2>&1 || true)
 if echo "$CONTRIB_RESPONSE" | grep -q "infra.resources"; then
     pass "GET /api/admin/contributions includes infra.resources"
 else
@@ -88,7 +119,7 @@ fi
 RPC_BODY='{"evidence":{"authz_checked":true,"authz_allowed":true}}'
 for rpc in resources types providers; do
     code=$(curl -s -o /tmp/scenario-92-$rpc.json -w '%{http_code}' \
-        -X POST -H 'Content-Type: application/json' \
+        -X POST -H 'Content-Type: application/json' -H "$AUTH_HEADER" \
         -d "$RPC_BODY" "$BASE_URL/api/infra-admin/$rpc" || echo "000")
     if [ "$code" = "200" ]; then
         pass "POST /api/infra-admin/$rpc returns 200"
@@ -98,7 +129,7 @@ for rpc in resources types providers; do
 done
 
 # Asset page reachable (proves embed.FS + middleware wiring).
-if curl -fs "$BASE_URL/admin/infra-admin/new.html" | grep -q '<title>Draft New Infra Resource</title>'; then
+if curl -fs -H "$AUTH_HEADER" "$BASE_URL/admin/infra-admin/new.html" | grep -q '<title>Draft New Infra Resource</title>'; then
     pass "GET /admin/infra-admin/new.html serves the form-builder page"
 else
     fail "new.html not served correctly"


### PR DESCRIPTION
## Summary

PR-2 of the infra-admin cascade — depends on **workflow#791** ([host-side infra.admin module](https://github.com/GoCodeAlone/workflow/pull/791)). Adds scenario 92 to the regression harness exercising the typed admin RPC surface + form-builder UI end-to-end.

- 12 Playwright specs in the central `e2e/tests/` tree (per plan-adversarial I1 fix; verified existing harness layout against scenarios 20/21/22).
- Stub + DO-dry-run variants share the same docker-compose; `VARIANT` env toggles between `config/app.yaml` and `config/app-do-dryrun.yaml`.
- PASS/FAIL prefixed `test/run.sh` does config validation → HTTP smoke (contributions + 3 RPCs + asset page) → wfctl CLI smoke (plan §CLI end-to-end smoke) → Playwright.
- `test/EXPLORATORY.md` template ready for the T27 post-merge `playwright-cli` exploratory pass.

## Locked-plan scope manifest (PR-2 row)

| PR # | Title | Tasks | Branch |
|------|-------|-------|--------|
| 2 | feat(scenarios/92): infra-admin-demo with stub + DO dry-run variants + Playwright | T21, T22, T23, T24, T25, T27 (template) | `feat/scenario-92-infra-admin-demo-2026-05-27T1534` (this PR) |

Locked manifest at `/Users/jon/workspace/docs/plans/2026-05-27-infra-admin-dynamic.md` (status: `Locked 2026-05-27T15:34:13Z`). No silent rescoping.

## Dependency

**PR-1 (workflow#791)** must merge first. Playwright runtime tests cannot pass until:
1. PR-1's `infra.admin` host module ships in workflow `main`.
2. `seed/seed.sh` builds the workflow server + workflow-plugin-admin binaries against `main` HEAD.
3. The resulting `workflow-admin:scenario-92` docker image boots cleanly.

Pre-merge validation here is restricted to:
- ✅ Static checks on YAML / JSON / shell scripts (yaml.safe_load, jq, shellcheck)
- ✅ `npx playwright test --list` parses all 12 specs (verified locally)
- ⏸ Full runtime test (`./seed/seed.sh && ./test/run.sh`) gated on PR-1 merge

## Architecture decisions cited

- `decisions/0002-infra-admin-host-module.md` — engine-side carve-out justified (3 cycles documented the plugin path's infeasibility without engine SDK extensions).
- `decisions/0003-infra-admin-t17-assertion-tier-amendment.md` — integration-test assertion-tier amendment.

## Files (+945 lines)

- `scenarios/92-infra-admin-demo/scenario.yaml` — id=92, category=C, status=testable
- `scenarios/92-infra-admin-demo/README.md` — quickstart + variants
- `scenarios/92-infra-admin-demo/config/app.yaml` — stub variant (design §App Integration block verbatim)
- `scenarios/92-infra-admin-demo/config/app-do-dryrun.yaml` — adds DO provider, no token
- `scenarios/92-infra-admin-demo/docker-compose.yml` — `workflow-admin:scenario-92` image on `127.0.0.1:18092`
- `scenarios/92-infra-admin-demo/seed/seed.sh` — build server + admin plugin binaries → docker image → up + waits `/healthz`
- `scenarios/92-infra-admin-demo/test/run.sh` — PASS/FAIL runner (config validation + HTTP smoke + wfctl CLI smoke + Playwright)
- `scenarios/92-infra-admin-demo/test/EXPLORATORY.md` — T27 template (post-merge exploratory pass)
- `e2e/tests/scenario-92-infra-admin.spec.ts` — 12 tests, central tree
- `scenarios.json` — registration entry

## Test plan

- [x] `scenario.yaml` parses as valid YAML
- [x] `config/app.yaml` + `config/app-do-dryrun.yaml` valid YAML
- [x] `scenarios.json` registration entry valid (`python3 -c "import json; json.load(open('scenarios.json'))"`)
- [x] `seed/seed.sh` + `test/run.sh` `chmod +x`
- [x] `e2e/tests/scenario-92-infra-admin.spec.ts` parses (`npx playwright test --list` → 12 tests listed)
- [ ] **Gated on PR-1 merge**: `./seed/seed.sh` builds + boots `workflow-admin:scenario-92` on `:18092` → `/healthz` returns 200
- [ ] **Gated on PR-1 merge**: `./test/run.sh` PASS for config-validation + HTTP smoke + wfctl CLI smoke + 12 Playwright tests
- [ ] **Gated on PR-1 merge + PR-2 merge**: T27 exploratory pass via `playwright-cli` skill produces filled `test/EXPLORATORY.md` + screenshots

## Out of scope (per locked manifest)

- v1.1 deferrals: TriggerAction mutation surface, audit-viewer UI, live-cloud parity tests, types/providers/actions asset pages
- IaCProviderRegionLister gRPC extension (filed as workflow follow-up)
- Workspace-CI cross-repo proto-vendor staleness job (filed as follow-up)