### PR TITLE
Test scenario 90 rejects hardcoded admin shell

### DIFF
--- a/scenarios/90-admin-tailnet-demo/seed/seed.sh
+++ b/scenarios/90-admin-tailnet-demo/seed/seed.sh
@@ -89,6 +89,11 @@ for repo_name in "${provider_repos[@]}"; do
 done
 
 cp -R "$PLUGIN_ADMIN_REPO/internal/ui_dist/." "$BUILD_DIR/admin-ui/"
+if grep -R -E 'data-panel="(identity|authorization)-panel"|Identity provider|Authorization mode' "$BUILD_DIR/admin-ui" >/dev/null; then
+  echo "ERROR: selected workflow-plugin-admin UI contains hardcoded admin surfaces" >&2
+  echo "       Use a contribution-driven workflow-plugin-admin build, such as v1.1.6 or newer." >&2
+  exit 1
+fi
 if [ -d "$PLUGIN_AUTHZ_UI_REPO/ui/dist" ]; then
   cp -R "$PLUGIN_AUTHZ_UI_REPO/ui/dist/." "$BUILD_DIR/authz-ui/"
 else

--- a/scenarios/90-admin-tailnet-demo/test/run.sh
+++ b/scenarios/90-admin-tailnet-demo/test/run.sh
@@ -60,6 +60,11 @@ fi
 
 admin="$(curl -fsS "$BASE/admin/")"
 contains "$admin" "<title>Workflow Admin</title>" "Admin shell is served by Workflow static.fileserver"
+if grep -E 'data-panel="(identity|authorization)-panel"|Identity provider|Authorization mode' <<<"$admin" >/dev/null; then
+  fail "Admin shell must be contribution-driven, not hardcoded to auth/authz surfaces"
+else
+  pass "Admin shell is contribution-driven"
+fi
 
 authz_page="$(curl -fsS "$BASE/admin/authz/")"
 contains "$authz_page" "<title>Authz Policy Manager</title>" "Authz UI plugin assets are served"


### PR DESCRIPTION
## Summary
- fail scenario 90 seeding when selected workflow-plugin-admin UI still contains hardcoded identity/authz panels
- assert the served admin shell is contribution-driven in the scenario test

## Verification
- bash -n scenarios/90-admin-tailnet-demo/seed/seed.sh && bash -n scenarios/90-admin-tailnet-demo/test/run.sh && git diff --check
- PLUGIN_ADMIN_REPO=/Users/jon/workspace/workflow-plugin-admin/.worktrees/fix-dynamic-admin-shell ./test/run.sh from scenarios/90-admin-tailnet-demo: PASS=42 FAIL=0
- grep against stale local workflow-plugin-admin checkout detects data-panel=identity-panel, data-panel=authorization-panel, Identity provider, and Authorization mode