### PR TITLE
fix: gate scenario 90 admin with workflow auth

### DIFF
--- a/scenarios/90-admin-tailnet-demo/README.md
+++ b/scenarios/90-admin-tailnet-demo/README.md
@@ -9,6 +9,11 @@ does not contain or run an application-specific Python/Node/Ruby web harness.
 - Admin contribution API: <http://localhost:18080/api/admin/contributions>
 - Auth provider catalog API: <http://localhost:18080/api/admin/auth/providers>
 
+The scenario creates an admin user during tests:
+
+- Email: `admin@tailnet`
+- Password: `admin-password`
+
 The image is built by `seed/seed.sh` from local checkouts:
 
 - `workflow` server binary

--- a/scenarios/90-admin-tailnet-demo/config/app.yaml
+++ b/scenarios/90-admin-tailnet-demo/config/app.yaml
@@ -8,6 +8,15 @@ modules:
     type: http.router
     dependsOn: [http]
 
+  - name: auth
+    type: auth.jwt
+    config:
+      secret: scenario-90-admin-jwt-secret-do-not-use-in-prod
+      issuer: scenario-90-admin
+      tokenExpiry: 24h
+      allowRegistration: true
+    dependsOn: [router]
+
   - name: admin
     type: admin.dashboard
     config:
@@ -85,7 +94,16 @@ workflows:
   http:
     server: http
     router: router
-    routes: []
+    routes:
+      - method: POST
+        path: /api/admin/auth/register
+        handler: auth
+      - method: POST
+        path: /api/admin/auth/login
+        handler: auth
+      - method: GET
+        path: /api/admin/auth/profile
+        handler: auth
 
 pipelines:
   healthz:
@@ -144,6 +162,16 @@ pipelines:
         path: /api/admin/contributions
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: contribution-input
         type: step.set
         config:
@@ -188,6 +216,16 @@ pipelines:
         path: /api/admin/auth/providers
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: catalog
         type: step.auth_provider_catalog
         config: &auth_provider_catalog_config
@@ -306,6 +344,16 @@ pipelines:
         path: /api/admin/auth/config
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: catalog
         type: step.auth_provider_catalog
         config: *auth_provider_catalog_config
@@ -339,6 +387,16 @@ pipelines:
         path: /api/admin/auth/providers/auth0
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: describe
         type: step.auth0_auth_provider_describe
         config:
@@ -358,6 +416,16 @@ pipelines:
         path: /api/admin/auth/providers/entra
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: describe
         type: step.entra_auth_provider_describe
         config:
@@ -377,6 +445,16 @@ pipelines:
         path: /api/admin/auth/providers/ory-kratos
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: describe
         type: step.ory_kratos_auth_provider_describe
         config:
@@ -395,6 +473,16 @@ pipelines:
         path: /api/admin/auth/providers/ory-hydra
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: describe
         type: step.ory_hydra_auth_provider_describe
         config:
@@ -413,6 +501,16 @@ pipelines:
         path: /api/admin/auth/providers/ory-polis
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: describe
         type: step.ory_polis_auth_provider_describe
         config:
@@ -431,6 +529,16 @@ pipelines:
         path: /api/admin/auth/providers/scalekit
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: describe
         type: step.scalekit_auth_provider_describe
         config:
@@ -449,6 +557,16 @@ pipelines:
         path: /api/authz/capabilities
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: respond
         type: step.json_response
         config:
@@ -482,6 +600,16 @@ pipelines:
         path: /api/authz/scopes
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: respond
         type: step.json_response
         config:
@@ -523,6 +651,16 @@ pipelines:
         path: /api/authz/roles
         method: GET
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: lookup
         type: step.authz_role_lookup
         config:
@@ -549,6 +687,16 @@ pipelines:
         path: /api/authz/enforce
         method: POST
     steps:
+      - name: parse_auth
+        type: step.request_parse
+        config:
+          parse_headers: [Authorization]
+      - name: authenticate
+        type: step.auth_validate
+        config:
+          auth_module: auth
+          token_source: steps.parse_auth.headers.Authorization
+          subject_field: subject
       - name: enforce
         type: step.authz_enforce
         config:

--- a/scenarios/90-admin-tailnet-demo/seed/seed.sh
+++ b/scenarios/90-admin-tailnet-demo/seed/seed.sh
@@ -24,11 +24,19 @@ admin_ui_dir_has_hardcoded_surfaces() {
   grep -R -E 'data-panel="(identity|authorization)-panel"|Identity provider|Authorization mode' "$ui_dir" >/dev/null 2>&1
 }
 
+admin_ui_dir_has_auth_gate() {
+  local ui_dir="$1"
+  grep -R 'data-login-endpoint' "$ui_dir" >/dev/null 2>&1 &&
+    grep -R 'data-token-storage-key' "$ui_dir" >/dev/null 2>&1 &&
+    grep -R 'Authorization' "$ui_dir" >/dev/null 2>&1
+}
+
 admin_repo_is_usable() {
   local repo="$1"
   [ -f "$repo/go.mod" ] &&
     [ -d "$repo/internal/ui_dist" ] &&
-    ! admin_ui_dir_has_hardcoded_surfaces "$repo/internal/ui_dist"
+    ! admin_ui_dir_has_hardcoded_surfaces "$repo/internal/ui_dist" &&
+    admin_ui_dir_has_auth_gate "$repo/internal/ui_dist"
 }
 
 find_admin_repo() {
@@ -39,7 +47,8 @@ find_admin_repo() {
 
   local root="$WORKSPACE_ROOT/workflow-plugin-admin"
   local candidate
-  for candidate in "$root" "$root/.worktrees/fix-dynamic-admin-shell"; do
+  for candidate in "$root" "$root"/.worktrees/*; do
+    [ -d "$candidate" ] || continue
     if admin_repo_is_usable "$candidate"; then
       echo "$candidate"
       return 0
@@ -56,7 +65,7 @@ find_admin_repo() {
   fi
 
   echo "ERROR: no contribution-driven workflow-plugin-admin checkout found under $root" >&2
-  echo "       Update workflow-plugin-admin to v1.1.6 or newer, or set PLUGIN_ADMIN_REPO explicitly." >&2
+  echo "       Update workflow-plugin-admin to v1.1.7 or newer, or set PLUGIN_ADMIN_REPO explicitly." >&2
   return 1
 }
 
@@ -132,7 +141,12 @@ done
 cp -R "$PLUGIN_ADMIN_REPO/internal/ui_dist/." "$BUILD_DIR/admin-ui/"
 if admin_ui_dir_has_hardcoded_surfaces "$BUILD_DIR/admin-ui"; then
   echo "ERROR: selected workflow-plugin-admin UI contains hardcoded admin surfaces" >&2
-  echo "       Use a contribution-driven workflow-plugin-admin build, such as v1.1.6 or newer." >&2
+  echo "       Use a contribution-driven workflow-plugin-admin build, such as v1.1.7 or newer." >&2
+  exit 1
+fi
+if ! admin_ui_dir_has_auth_gate "$BUILD_DIR/admin-ui"; then
+  echo "ERROR: selected workflow-plugin-admin UI does not include token-aware admin loading" >&2
+  echo "       Use workflow-plugin-admin with login-aware shell assets, or set PLUGIN_ADMIN_REPO explicitly." >&2
   exit 1
 fi
 if [ -d "$PLUGIN_AUTHZ_UI_REPO/ui/dist" ]; then

--- a/scenarios/90-admin-tailnet-demo/test/run.sh
+++ b/scenarios/90-admin-tailnet-demo/test/run.sh
@@ -60,6 +60,8 @@ fi
 
 admin="$(curl -fsS "$BASE/admin/")"
 contains "$admin" "<title>Workflow Admin</title>" "Admin shell is served by Workflow static.fileserver"
+contains "$admin" 'data-login-endpoint="/api/admin/auth/login"' "Admin shell advertises login endpoint"
+contains "$admin" 'id="login-form"' "Admin shell renders login form"
 if grep -E 'data-panel="(identity|authorization)-panel"|Identity provider|Authorization mode' <<<"$admin" >/dev/null; then
   fail "Admin shell must be contribution-driven, not hardcoded to auth/authz surfaces"
 else
@@ -69,18 +71,52 @@ fi
 authz_page="$(curl -fsS "$BASE/admin/authz/")"
 contains "$authz_page" "<title>Authz Policy Manager</title>" "Authz UI plugin assets are served"
 
-contribs="$(curl -fsS "$BASE/api/admin/contributions")"
+unauth_contribs_code="$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/admin/contributions" || echo "000")"
+if [ "$unauth_contribs_code" = "401" ]; then
+  pass "Anonymous admin contributions API is unauthorized"
+else
+  fail "Anonymous admin contributions API expected 401, got $unauth_contribs_code"
+fi
+
+unauth_authz_code="$(curl -s -o /dev/null -w "%{http_code}" "$BASE/api/authz/roles" || echo "000")"
+if [ "$unauth_authz_code" = "401" ]; then
+  pass "Anonymous authz roles API is unauthorized"
+else
+  fail "Anonymous authz roles API expected 401, got $unauth_authz_code"
+fi
+
+register_body="$(curl -sfS -X POST "$BASE/api/admin/auth/register" \
+  -H "content-type: application/json" \
+  -d '{"email":"admin@tailnet","password":"admin-password","name":"Scenario Admin"}' 2>/dev/null || true)"
+token="$(jq -r '.token // .access_token // empty' <<<"$register_body" 2>/dev/null || true)"
+if [ -z "$token" ]; then
+  login_body="$(curl -sfS -X POST "$BASE/api/admin/auth/login" \
+    -H "content-type: application/json" \
+    -d '{"email":"admin@tailnet","password":"admin-password"}' 2>/dev/null || true)"
+  token="$(jq -r '.token // .access_token // empty' <<<"$login_body" 2>/dev/null || true)"
+fi
+if [ -n "$token" ]; then
+  pass "Admin login returns JWT token"
+else
+  fail "Admin login did not return a JWT token"
+fi
+AUTH_HEADER="Authorization: Bearer $token"
+
+profile="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/admin/auth/profile")"
+contains "$profile" '"email":"admin@tailnet"' "Admin token validates through auth.jwt profile route"
+
+contribs="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/admin/contributions")"
 contains "$contribs" '"id":"authz-roles"' "Admin plugin registered authz contribution"
 contains "$contribs" '"render_mode":"iframe"' "Admin contribution uses pluggable iframe render mode"
 
-catalog="$(curl -fsS "$BASE/api/admin/auth/providers")"
+catalog="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/admin/auth/providers")"
 json_len_at_least "$catalog" '.providers' 9 "Auth provider catalog includes composed providers"
 contains "$catalog" '"implementation":"workflow-plugin-auth0"' "Catalog includes Auth0 plugin descriptor"
 contains "$catalog" '"implementation":"workflow-plugin-okta"' "Catalog includes Okta plugin descriptor"
 contains "$catalog" '"implementation":"workflow-plugin-ory-kratos"' "Catalog includes Ory Kratos plugin descriptor"
 contains "$catalog" '"implementation":"workflow-plugin-scalekit"' "Catalog includes Scalekit plugin descriptor"
 
-auth_config="$(curl -fsS "$BASE/api/admin/auth/config")"
+auth_config="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/admin/auth/config")"
 contains "$auth_config" '"groups"' "Auth plugin exposes admin config groups"
 contains "$auth_config" '"Passkey relying party ID"' "Auth config exposes passkey control metadata"
 contains "$auth_config" '"M2M client secret"' "Auth config includes descriptor-backed provider secret control"
@@ -91,25 +127,25 @@ else
 fi
 
 for provider in auth0 entra ory-kratos ory-hydra ory-polis scalekit; do
-  body="$(curl -fsS "$BASE/api/admin/auth/providers/$provider")"
+  body="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/admin/auth/providers/$provider")"
   contains "$body" '"providers"' "Provider $provider route is backed by provider plugin step"
   contains "$body" "\"id\":\"$provider\"" "Provider $provider descriptor has expected id"
 done
 
-scopes="$(curl -fsS "$BASE/api/authz/scopes")"
+scopes="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/authz/scopes")"
 contains "$scopes" '"frontend:orders:read"' "Authz scopes endpoint includes frontend scope"
 contains "$scopes" '"admin:authz.roles:update"' "Authz scopes endpoint includes admin scope"
 
-roles="$(curl -fsS "$BASE/api/authz/roles")"
+roles="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/authz/roles")"
 contains "$roles" '"admin@tailnet"' "Authz roles endpoint renders role assignments"
 contains "$roles" '"frontend:orders:read"' "Authz roles endpoint carries selectable scope values"
 
-caps="$(curl -fsS "$BASE/api/authz/capabilities")"
+caps="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/authz/capabilities")"
 contains "$caps" '"mode":"rbac"' "Authz capabilities report RBAC"
 contains "$caps" '"mode":"abac"' "Authz capabilities report ABAC"
 contains "$caps" '"mode":"rebac"' "Authz capabilities report ReBAC"
 
-enforce="$(curl -fsS -H 'content-type: application/json' -d '{"subject":"admin@tailnet","object":"authz.roles","action":"update"}' "$BASE/api/authz/enforce")"
+enforce="$(curl -fsS -H "$AUTH_HEADER" -H 'content-type: application/json' -d '{"subject":"admin@tailnet","object":"authz.roles","action":"update"}' "$BASE/api/authz/enforce")"
 contains "$enforce" '"allowed":true' "Authz UI plugin enforce step permits expected action"
 contains "$enforce" '"reason":"scenario fixture grants admin role"' "Authz enforce response comes from plugin step config"
 


### PR DESCRIPTION
## Summary
- compose scenario 90 with workflow-plugin-auth `auth.jwt` instead of exposing admin APIs anonymously
- require bearer auth on admin contribution, auth provider, and authz management APIs
- make seed require workflow-plugin-admin v1.1.7 login-aware dynamic shell assets
- document scenario admin credentials for local review

## Verification
- bash -n scenarios/90-admin-tailnet-demo/seed/seed.sh && bash -n scenarios/90-admin-tailnet-demo/test/run.sh && ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml-ok"' scenarios/90-admin-tailnet-demo/config/app.yaml && git diff --check\n- ./test/run.sh from scenarios/90-admin-tailnet-demo: PASS=48 FAIL=0\n- Playwright browser QA: login form visible before auth, plugin nav hidden before auth, login succeeds, authz contribution appears, authz iframe loads plugin UI\n\n## Runtime\n- Local app remains running at http://127.0.0.1:18080/admin/\n- Tailscale sidecar starts, but without TS_AUTHKEY or reusable state it remains idle as designed