### PR TITLE
Fix Scenario 90 runtime data dir

### DIFF
--- a/scenarios/90-admin-tailnet-demo/seed/seed.sh
+++ b/scenarios/90-admin-tailnet-demo/seed/seed.sh
@@ -127,7 +127,7 @@ build_plugin() {
 
 BUILD_DIR="$SCENARIO_DIR/.build"
 rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR/plugins" "$BUILD_DIR/admin-ui" "$BUILD_DIR/authz-ui" "$BUILD_DIR/app-ui"
+mkdir -p "$BUILD_DIR/plugins" "$BUILD_DIR/admin-ui" "$BUILD_DIR/authz-ui" "$BUILD_DIR/app-ui" "$BUILD_DIR/data"
 cp "$SCENARIO_DIR/config/app.yaml" "$BUILD_DIR/app.yaml"
 
 require_go_module "$WORKFLOW_REPO"
@@ -199,6 +199,7 @@ cat > "$BUILD_DIR/Dockerfile" <<'DOCKERFILE'
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --chown=nonroot:nonroot server /usr/local/bin/server
 COPY --chown=nonroot:nonroot plugins/ /data/plugins/
+COPY --chown=nonroot:nonroot data/ /data/data/
 COPY --chown=nonroot:nonroot app.yaml /data/app.yaml
 COPY --chown=nonroot:nonroot admin-ui/ /opt/workflow-admin-ui/
 COPY --chown=nonroot:nonroot authz-ui/ /opt/workflow-authz-ui/


### PR DESCRIPTION
## Summary
- create a writable `/data/data` directory in the generated Scenario 90 image
- copy it with `--chown=nonroot:nonroot` so SQLite-backed admin modules can initialize under the distroless nonroot user

## Root cause
Docker was available, but Scenario 90 failed at startup because `workflow-plugin-admin` contributes `admin-feature-flags` with `db_path: data/featureflags.db`. The generated distroless image ran from `/data` as `nonroot` without a writable `/data/data` parent directory, so the feature flag module factory failed to create/open its SQLite store and returned nil.

## Verification
- `./test/run.sh`
  - Docker image built: `workflow-admin:scenario-90`
  - container started and `/healthz` became ready in 5s
  - admin/auth/authz/app smoke completed
  - result: `PASS=67 FAIL=0`
- `bash -n scenarios/90-admin-tailnet-demo/seed/seed.sh scenarios/90-admin-tailnet-demo/test/run.sh`
- `git diff --check`

## Runtime launch transcript
Build/launch:
```sh
$ ./test/run.sh
Building workflow server...
Building workflow-plugin-admin...
Building workflow-plugin-auth...
Building workflow-plugin-authz-ui...
Building workflow-plugin-auth0...
Building workflow-plugin-entra...
Building workflow-plugin-okta...
Building workflow-plugin-sso...
Building workflow-plugin-ory-kratos...
Building workflow-plugin-ory-hydra...
Building workflow-plugin-ory-polis...
Building workflow-plugin-scalekit...
Building workflow-admin:scenario-90...
COPY --chown=nonroot:nonroot data/ /data/data/
Stack ready at http://127.0.0.1:18080 (took 5s)
PASS: Admin login returns JWT token
PASS: Auth provider catalog includes composed providers
PASS: Authz UI plugin enforce step permits expected action
PASS: Admin can update orders through authz enforcement
PASS: App logs do not mention Python
PASS=67 FAIL=0
```

Failure-signature scrape: clean for the original `factory for module type "featureflag.service" returned nil` startup failure.
Verdict: PASS