### PR TITLE
Prove Scenario 90 admin authz fidelity

### DIFF
--- a/scenarios/90-admin-tailnet-demo/config/app.yaml
+++ b/scenarios/90-admin-tailnet-demo/config/app.yaml
@@ -236,6 +236,131 @@ pipelines:
             primary_app: "/"
             admin_app: "/admin/"
 
+  scenario90-role-bootstrap:
+    trigger:
+      type: http
+      config:
+        path: /api/scenario90/seed/roles
+        method: POST
+    steps:
+      - name: parse_seed
+        type: step.request_parse
+        config:
+          parse_headers: [X-Scenario90-Seed-Token]
+      - name: route-seed-token
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT 1 AS allowed
+            WHERE ? != '' AND ? = ?
+          params:
+            - '{{ index .steps "parse_seed" "headers" "X-Scenario90-Seed-Token" }}'
+            - '{{ index .steps "parse_seed" "headers" "X-Scenario90-Seed-Token" }}'
+            - '${SCENARIO90_SEED_TOKEN}'
+          mode: single
+      - name: route-seed-grant
+        type: step.conditional
+        config:
+          field: steps.route-seed-token.found
+          routes:
+            'true': create-role-table
+          default: deny-seed
+      - &scenario90_create_role_table_step
+        name: create-role-table
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: |
+            CREATE TABLE IF NOT EXISTS scenario90_role_assignments (
+              user TEXT NOT NULL,
+              role TEXT NOT NULL,
+              context TEXT NOT NULL,
+              scopes_json TEXT NOT NULL,
+              updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+              PRIMARY KEY (user, role, context)
+            )
+          ignore_error: true
+      - &scenario90_seed_admin_scopes_step
+        name: seed-admin-scopes
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: |
+            INSERT OR IGNORE INTO scenario90_role_assignments (user, role, context, scopes_json)
+            VALUES (?, ?, ?, ?)
+          params:
+            - admin@tailnet
+            - admin
+            - admin
+            - '["admin:auth.config:read","admin:auth.config:update","admin:auth.providers.read","admin:authz.roles:read","admin:authz.roles:update"]'
+      - &scenario90_seed_support_admin_authz_read_step
+        name: seed-support-admin-authz-read
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: |
+            INSERT OR IGNORE INTO scenario90_role_assignments (user, role, context, scopes_json)
+            VALUES (?, ?, ?, ?)
+          params:
+            - app-user@tailnet
+            - support-admin-read
+            - admin
+            - '["admin:authz.roles:read"]'
+      - &scenario90_seed_delegate_auth_admin_step
+        name: seed-delegate-auth-admin
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: |
+            INSERT OR IGNORE INTO scenario90_role_assignments (user, role, context, scopes_json)
+            VALUES (?, ?, ?, ?)
+          params:
+            - delegated-admin@tailnet
+            - identity-admin
+            - admin
+            - '["admin:auth.config:read","admin:auth.providers.read"]'
+      - &scenario90_seed_admin_frontend_step
+        name: seed-admin-frontend
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: |
+            INSERT OR IGNORE INTO scenario90_role_assignments (user, role, context, scopes_json)
+            VALUES (?, ?, ?, ?)
+          params:
+            - admin@tailnet
+            - admin
+            - frontend
+            - '["frontend:orders:read","frontend:orders:update"]'
+      - &scenario90_seed_support_frontend_step
+        name: seed-support-frontend
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: |
+            INSERT OR IGNORE INTO scenario90_role_assignments (user, role, context, scopes_json)
+            VALUES (?, ?, ?, ?)
+          params:
+            - app-user@tailnet
+            - support
+            - frontend
+            - '["frontend:orders:read"]'
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            seeded: true
+            roles: ["admin", "support", "delegated-admin"]
+      - name: deny-seed
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            seeded: false
+            reason: missing scenario seed token
+
   app-access:
     trigger:
       type: http
@@ -253,14 +378,28 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
-      - name: route-by-user
+      - *scenario90_create_role_table_step
+      - name: find-admin-profile
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND role = ? AND context = ?
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin
+          mode: single
+      - name: route-by-admin-profile
         type: step.conditional
         config:
-          field: steps.authenticate.email
+          field: steps.find-admin-profile.found
           routes:
-            admin@tailnet: admin-access
-            app-user@tailnet: support-access
-          default: viewer-access
+            'true': admin-access
+          default: find-support-profile
       - name: admin-access
         type: step.json_response
         config:
@@ -271,6 +410,27 @@ pipelines:
             frontend_scopes: ["frontend:orders:read", "frontend:orders:update"]
             admin_scopes: ["admin:auth.config:read", "admin:auth.config:update", "admin:authz.roles:read", "admin:authz.roles:update"]
             visible_panels: ["orders", "order-update", "admin-auth", "admin-authz"]
+      - name: find-support-profile
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND role = ? AND context = ?
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - support
+            - frontend
+          mode: single
+      - name: route-by-support-profile
+        type: step.conditional
+        config:
+          field: steps.find-support-profile.found
+          routes:
+            'true': support-access
+          default: viewer-access
       - name: support-access
         type: step.json_response
         config:
@@ -309,51 +469,49 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
-      - name: route-by-user
+      - *scenario90_create_role_table_step
+      - name: find-orders-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ?
+              AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - frontend
+            - frontend:orders:read
+          mode: single
+      - name: route-by-orders-read
         type: step.conditional
         config:
-          field: steps.authenticate.email
+          field: steps.find-orders-read.found
           routes:
-            admin@tailnet: admin-read-enforce
-            app-user@tailnet: support-read-enforce
+            'true': allow-read-enforce
           default: deny-read-enforce
-      - name: admin-read-enforce
+      - name: allow-read-enforce
         type: step.authz_enforce
         config:
-          subject: admin@tailnet
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: orders
           action: read
           permitted: true
-          reason: frontend:orders:read granted by admin role
-      - name: admin-read-response
+          reason: frontend:orders:read granted by role assignment
+      - name: allow-read-response
         type: step.json_response
         config:
           status: 200
           body:
-            allowed: { _from: "steps.admin-read-enforce.permitted" }
-            reason: { _from: "steps.admin-read-enforce.reason" }
-            orders:
-              - id: ORD-1001
-                customer: Northwind
-                status: ready
-              - id: ORD-1002
-                customer: Contoso
-                status: review
-      - name: support-read-enforce
-        type: step.authz_enforce
-        config:
-          subject: app-user@tailnet
-          resource: orders
-          action: read
-          permitted: true
-          reason: frontend:orders:read granted by support role
-      - name: support-read-response
-        type: step.json_response
-        config:
-          status: 200
-          body:
-            allowed: { _from: "steps.support-read-enforce.permitted" }
-            reason: { _from: "steps.support-read-enforce.reason" }
+            allowed: { _from: "steps.allow-read-enforce.permitted" }
+            reason: { _from: "steps.allow-read-enforce.reason" }
             orders:
               - id: ORD-1001
                 customer: Northwind
@@ -364,7 +522,7 @@ pipelines:
       - name: deny-read-enforce
         type: step.authz_enforce
         config:
-          subject: viewer
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: orders
           action: read
           permitted: false
@@ -394,35 +552,56 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
-      - name: route-by-user
+      - *scenario90_create_role_table_step
+      - name: find-orders-update
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ?
+              AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - frontend
+            - frontend:orders:update
+          mode: single
+      - name: route-by-orders-update
         type: step.conditional
         config:
-          field: steps.authenticate.email
+          field: steps.find-orders-update.found
           routes:
-            admin@tailnet: admin-update-enforce
+            'true': allow-update-enforce
           default: deny-update-enforce
-      - name: admin-update-enforce
+      - name: allow-update-enforce
         type: step.authz_enforce
         config:
-          subject: admin@tailnet
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: orders
           action: update
           permitted: true
-          reason: frontend:orders:update granted by admin role
-      - name: admin-update-response
+          reason: frontend:orders:update granted by role assignment
+      - name: allow-update-response
         type: step.json_response
         config:
           status: 200
           body:
-            allowed: { _from: "steps.admin-update-enforce.permitted" }
-            reason: { _from: "steps.admin-update-enforce.reason" }
+            allowed: { _from: "steps.allow-update-enforce.permitted" }
+            reason: { _from: "steps.allow-update-enforce.reason" }
             updated_order:
               id: ORD-1002
               status: priority-review
       - name: deny-update-enforce
         type: step.authz_enforce
         config:
-          subject: non-admin
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: orders
           action: update
           permitted: false
@@ -452,24 +631,64 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
-      - name: route-by-user
-        type: step.conditional
+      - *scenario90_create_role_table_step
+      - name: find-auth-nav-grant
+        type: step.db_query
         config:
-          field: steps.authenticate.email
-          routes:
-            admin@tailnet: admin-grants
-            app-user@tailnet: support-grants
-          default: viewer-grants
-      - name: admin-grants
-        type: step.set
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.config:read
+          mode: single
+      - name: find-authz-nav-grant
+        type: step.db_query
         config:
-          values:
-            app_context: admin
-            granted_permissions:
-              - admin:auth.config:read
-              - admin:auth.config:update
-              - admin:authz.roles:read
-              - admin:authz.roles:update
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:authz.roles:read
+          mode: single
+      - name: find-authz-update-grant
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:authz.roles:update
+          mode: single
       - name: describe-auth-contribution
         type: step.auth_admin_contribution_describe
         config: {}
@@ -480,102 +699,151 @@ pipelines:
         input:
           contribution: { _from: "steps.describe-auth-contribution.contribution" }
       - name: admin-authz-contribution
-        type: step.set
+        type: step.authz_admin_contribution
         config:
-          values:
-            contribution:
-              id: authz-roles
-              title: Authorization
-              category: security
-              path: /admin/authz/
-              render_mode: iframe
-              app_context: admin
-              permissions:
-                - permission: admin:authz.roles:read
-                  resource: authz.roles
-                  action: read
-                - permission: admin:authz.roles:update
-                  resource: authz.roles
-                  action: update
+          admin_base_path: /admin/authz/
+          app_context: admin
+          admin:
+            id: authz-roles
+            title: Authorization
+            category: security
+            path: /admin/authz/
+            render_mode: iframe
+            app_context: admin
+            permissions:
+              - admin:authz.roles:read
+              - admin:authz.roles:update
       - name: register-authz
         type: step.admin_register_contribution
         config:
           module: admin
         input:
           contribution: { _from: "steps.admin-authz-contribution.contribution" }
-      - name: list
+      - name: route-nav-grants
+        type: step.conditional
+        config:
+          field: '{{ index .steps "find-auth-nav-grant" "found" }}|{{ index .steps "find-authz-nav-grant" "found" }}|{{ index .steps "find-authz-update-grant" "found" }}'
+          routes:
+            'true|true|true': list-both-admin
+            'true|true|false': list-both-readonly
+            'true|false|false': list-auth-only
+            'false|true|true': list-authz-admin
+            'false|true|false': list-authz-only
+          default: viewer-respond
+      - name: list-both-admin
         type: step.admin_list_contributions
         config:
           module: admin
+          contribution_steps: [register-auth, register-authz]
+          app_context: admin
+          granted_permissions: [admin:auth.config:read, admin:authz.roles:read, admin:authz.roles:update]
         input:
-          app_context: { _from: "steps.admin-grants.app_context" }
-          granted_permissions: { _from: "steps.admin-grants.granted_permissions" }
-      - name: respond
+          auth_contribution: { _from: "steps.register-auth.contribution" }
+          authz_contribution: { _from: "steps.register-authz.contribution" }
+          app_context: admin
+          granted_permissions: [admin:auth.config:read, admin:authz.roles:read, admin:authz.roles:update]
+      - name: respond-both-admin
         type: step.json_response
         config:
           status: 200
           body:
-            contributions: { _from: "steps.list.contributions" }
-      - name: support-grants
-        type: step.set
-        config:
-          values:
-            app_context: admin
-            granted_permissions:
-              - admin:authz.roles:read
-      - name: support-authz-contribution
-        type: step.set
-        config:
-          values:
-            contribution:
-              id: authz-roles
-              title: Authorization
-              category: security
-              path: /admin/authz/
-              render_mode: iframe
-              app_context: admin
-              permissions:
-                - permission: admin:authz.roles:read
-                  resource: authz.roles
-                  action: read
-      - name: support-register-authz
-        type: step.admin_register_contribution
-        config:
-          module: admin
-        input:
-          contribution: { _from: "steps.support-authz-contribution.contribution" }
-      - name: support-list
+            contributions: { _from: "steps.list-both-admin.contributions" }
+            granted_permissions: [admin:auth.config:read, admin:authz.roles:read, admin:authz.roles:update]
+      - name: list-both-readonly
         type: step.admin_list_contributions
         config:
           module: admin
+          contribution_steps: [register-auth, register-authz]
+          app_context: admin
+          granted_permissions: [admin:auth.config:read, admin:authz.roles:read]
         input:
-          app_context: { _from: "steps.support-grants.app_context" }
-          granted_permissions: { _from: "steps.support-grants.granted_permissions" }
-      - name: support-respond
+          auth_contribution: { _from: "steps.register-auth.contribution" }
+          authz_contribution: { _from: "steps.register-authz.contribution" }
+          app_context: admin
+          granted_permissions: [admin:auth.config:read, admin:authz.roles:read]
+      - name: respond-both-readonly
         type: step.json_response
         config:
           status: 200
           body:
-            contributions: { _from: "steps.support-list.contributions" }
-      - name: viewer-grants
-        type: step.set
+            contributions: { _from: "steps.list-both-readonly.contributions" }
+            granted_permissions: [admin:auth.config:read, admin:authz.roles:read]
+      - name: list-auth-only
+        type: step.admin_list_contributions
         config:
-          values:
-            app_context: admin
-            granted_permissions: []
+          module: admin
+          contribution_steps: [register-auth, register-authz]
+          app_context: admin
+          granted_permissions: [admin:auth.config:read]
+        input:
+          auth_contribution: { _from: "steps.register-auth.contribution" }
+          authz_contribution: { _from: "steps.register-authz.contribution" }
+          app_context: admin
+          granted_permissions: [admin:auth.config:read]
+      - name: respond-auth-only
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            contributions: { _from: "steps.list-auth-only.contributions" }
+            granted_permissions: [admin:auth.config:read]
+      - name: list-authz-admin
+        type: step.admin_list_contributions
+        config:
+          module: admin
+          contribution_steps: [register-auth, register-authz]
+          app_context: admin
+          granted_permissions: [admin:authz.roles:read, admin:authz.roles:update]
+        input:
+          auth_contribution: { _from: "steps.register-auth.contribution" }
+          authz_contribution: { _from: "steps.register-authz.contribution" }
+          app_context: admin
+          granted_permissions: [admin:authz.roles:read, admin:authz.roles:update]
+      - name: respond-authz-admin
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            contributions: { _from: "steps.list-authz-admin.contributions" }
+            granted_permissions: [admin:authz.roles:read, admin:authz.roles:update]
+      - name: list-authz-only
+        type: step.admin_list_contributions
+        config:
+          module: admin
+          contribution_steps: [register-auth, register-authz]
+          app_context: admin
+          granted_permissions: [admin:authz.roles:read]
+        input:
+          auth_contribution: { _from: "steps.register-auth.contribution" }
+          authz_contribution: { _from: "steps.register-authz.contribution" }
+          app_context: admin
+          granted_permissions: [admin:authz.roles:read]
+      - name: respond-authz-only
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            contributions: { _from: "steps.list-authz-only.contributions" }
+            granted_permissions: [admin:authz.roles:read]
       - name: viewer-list
         type: step.admin_list_contributions
         config:
           module: admin
+          contribution_steps: [register-auth, register-authz]
+          app_context: admin
+          granted_permissions: []
         input:
-          app_context: { _from: "steps.viewer-grants.app_context" }
-          granted_permissions: { _from: "steps.viewer-grants.granted_permissions" }
+          auth_contribution: { _from: "steps.register-auth.contribution" }
+          authz_contribution: { _from: "steps.register-authz.contribution" }
+          app_context: admin
+          granted_permissions: []
       - name: viewer-respond
         type: step.json_response
         config:
           status: 200
           body:
             contributions: { _from: "steps.viewer-list.contributions" }
+            granted_permissions: []
 
   auth-provider-catalog:
     trigger:
@@ -594,6 +862,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-provider-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.providers.read
+          mode: single
+      - name: route-by-auth-provider-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-provider-read.found
+          routes:
+            'true': catalog
+          default: deny-response
       - name: catalog
         type: step.auth_provider_catalog
         config: &auth_provider_catalog_config
@@ -704,6 +999,13 @@ pipelines:
           body:
             providers: { _from: "steps.catalog.providers" }
             warnings: { _from: "steps.catalog.warnings" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.providers.read
 
   auth-admin-config:
     trigger:
@@ -722,6 +1024,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-config-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.config:read
+          mode: single
+      - name: route-by-auth-config-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-config-read.found
+          routes:
+            'true': catalog
+          default: deny-response
       - name: catalog
         type: step.auth_provider_catalog
         config: *auth_provider_catalog_config
@@ -747,6 +1076,13 @@ pipelines:
             providers: { _from: "steps.catalog.providers" }
             warnings: { _from: "steps.describe.warnings" }
             secret_fields: { _from: "steps.describe.secret_fields" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.config:read
 
   auth-admin-config-validate:
     trigger:
@@ -766,6 +1102,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_request.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-config-update
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.config:update
+          mode: single
+      - name: route-by-auth-config-update
+        type: step.conditional
+        config:
+          field: steps.find-auth-config-update.found
+          routes:
+            'true': validate
+          default: deny-response
       - name: validate
         type: step.auth_admin_config_validate
         config:
@@ -784,6 +1147,13 @@ pipelines:
             errors: { _from: "steps.validate.errors" }
             warnings: { _from: "steps.validate.warnings" }
             secret_fields: { _from: "steps.validate.secret_fields" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.config:update
 
   describe-auth0-provider:
     trigger:
@@ -802,6 +1172,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-provider-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.providers.read
+          mode: single
+      - name: route-by-auth-provider-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-provider-read.found
+          routes:
+            'true': describe
+          default: deny-response
       - name: describe
         type: step.auth0_auth_provider_describe
         config:
@@ -813,6 +1210,13 @@ pipelines:
           status: 200
           body:
             providers: { _from: "steps.describe.providers" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.providers.read
 
   describe-entra-provider:
     trigger:
@@ -831,6 +1235,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-provider-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.providers.read
+          mode: single
+      - name: route-by-auth-provider-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-provider-read.found
+          routes:
+            'true': describe
+          default: deny-response
       - name: describe
         type: step.entra_auth_provider_describe
         config:
@@ -842,6 +1273,13 @@ pipelines:
           status: 200
           body:
             providers: { _from: "steps.describe.providers" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.providers.read
 
   describe-ory-kratos-provider:
     trigger:
@@ -860,6 +1298,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-provider-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.providers.read
+          mode: single
+      - name: route-by-auth-provider-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-provider-read.found
+          routes:
+            'true': describe
+          default: deny-response
       - name: describe
         type: step.ory_kratos_auth_provider_describe
         config:
@@ -870,6 +1335,13 @@ pipelines:
           status: 200
           body:
             providers: { _from: "steps.describe.providers" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.providers.read
 
   describe-ory-hydra-provider:
     trigger:
@@ -888,6 +1360,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-provider-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.providers.read
+          mode: single
+      - name: route-by-auth-provider-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-provider-read.found
+          routes:
+            'true': describe
+          default: deny-response
       - name: describe
         type: step.ory_hydra_auth_provider_describe
         config:
@@ -898,6 +1397,13 @@ pipelines:
           status: 200
           body:
             providers: { _from: "steps.describe.providers" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.providers.read
 
   describe-ory-polis-provider:
     trigger:
@@ -916,6 +1422,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-provider-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.providers.read
+          mode: single
+      - name: route-by-auth-provider-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-provider-read.found
+          routes:
+            'true': describe
+          default: deny-response
       - name: describe
         type: step.ory_polis_auth_provider_describe
         config:
@@ -926,6 +1459,13 @@ pipelines:
           status: 200
           body:
             providers: { _from: "steps.describe.providers" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.providers.read
 
   describe-scalekit-provider:
     trigger:
@@ -944,6 +1484,33 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-auth-provider-read
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:auth.providers.read
+          mode: single
+      - name: route-by-auth-provider-read
+        type: step.conditional
+        config:
+          field: steps.find-auth-provider-read.found
+          routes:
+            'true': describe
+          default: deny-response
       - name: describe
         type: step.scalekit_auth_provider_describe
         config:
@@ -954,6 +1521,13 @@ pipelines:
           status: 200
           body:
             providers: { _from: "steps.describe.providers" }
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:auth.providers.read
 
   authz-capabilities:
     trigger:
@@ -972,14 +1546,36 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-authz-read-grant
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT 1 AS found
+            FROM scenario90_role_assignments, json_each(scenario90_role_assignments.scopes_json)
+            WHERE user = ? AND context = ? AND json_each.value = ?
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:authz.roles:read
+          mode: single
+      - name: route-by-authz-read
+        type: step.conditional
+        config:
+          field: steps.find-authz-read-grant.found
+          routes:
+            'true': respond
+          default: deny-response
       - name: respond
         type: step.json_response
         config:
           status: 200
           body:
             module: authz-ui
-            provider: scenario-fixture
-            capabilities: [rbac, abac, rebac]
+            provider: workflow-scenario-policy
+            capabilities: [rbac]
             health: ok
             capability_descriptors:
               - mode: rbac
@@ -988,15 +1584,24 @@ pipelines:
                 source: workflow-plugin-authz-ui
                 health: ok
               - mode: abac
-                operations: [manage_policies]
-                configured: true
+                operations: []
+                configured: false
                 source: workflow-plugin-authz-ui
-                health: ok
+                health: unavailable
+                unsupported_reason: scenario 90 does not expose ABAC policy routes
               - mode: rebac
-                operations: [manage_relations]
-                configured: true
+                operations: []
+                configured: false
                 source: workflow-plugin-authz-ui
-                health: ok
+                health: unavailable
+                unsupported_reason: scenario 90 does not expose ReBAC relation routes
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:authz.roles:read
 
   authz-scopes:
     trigger:
@@ -1015,6 +1620,28 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
+      - *scenario90_create_role_table_step
+      - name: find-authz-read-grant
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT 1 AS found
+            FROM scenario90_role_assignments, json_each(scenario90_role_assignments.scopes_json)
+            WHERE user = ? AND context = ? AND json_each.value = ?
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:authz.roles:read
+          mode: single
+      - name: route-by-authz-read
+        type: step.conditional
+        config:
+          field: steps.find-authz-read-grant.found
+          routes:
+            'true': respond
+          default: deny-response
       - name: respond
         type: step.json_response
         config:
@@ -1048,6 +1675,13 @@ pipelines:
               owner_plugin: workflow-plugin-authz-ui
               owner_module: authz-ui
               category: admin
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            allowed: false
+            reason: missing admin:authz.roles:read
 
   authz-roles:
     trigger:
@@ -1066,24 +1700,61 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_auth.headers.Authorization
           subject_field: subject
-      - name: lookup
-        type: step.authz_role_lookup
+      - *scenario90_create_role_table_step
+      - name: find-authz-roles-read
+        type: step.db_query
         config:
-          subject: admin@tailnet
-          roles: [admin]
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:authz.roles:read
+          mode: single
+      - name: route-by-authz-roles-read
+        type: step.conditional
+        config:
+          field: steps.find-authz-roles-read.found
+          routes:
+            'true': fetch-roles
+          default: deny-read
+      - name: fetch-roles
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context, CAST(scopes_json AS BLOB) AS scopes
+            FROM scenario90_role_assignments
+            ORDER BY user, role, context
       - name: respond
         type: step.json_response
         config:
           status: 200
+          body_from: steps.fetch-roles.rows
+      - name: deny-read
+        type: step.authz_enforce
+        config:
+          subject: '{{ index .steps "authenticate" "email" }}'
+          resource: authz.roles
+          action: read
+          permitted: false
+          reason: missing admin:authz.roles:read
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 403
           body:
-            - user: admin@tailnet
-              role: admin
-              context: admin
-              scopes: ["admin:authz.roles:read", "admin:authz.roles:update"]
-            - user: app-user@tailnet
-              role: support
-              context: frontend
-              scopes: ["frontend:orders:read"]
+            allowed: false
+            reason: { _from: "steps.deny-read.reason" }
 
   authz-roles-add:
     trigger:
@@ -1103,33 +1774,81 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_request.headers.Authorization
           subject_field: subject
-      - name: route-by-user
+      - *scenario90_create_role_table_step
+      - name: find-authz-roles-update
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:authz.roles:update
+          mode: single
+      - name: route-by-authz-roles-update
         type: step.conditional
         config:
-          field: steps.authenticate.email
+          field: steps.find-authz-roles-update.found
           routes:
-            admin@tailnet: allow-update
+            'true': allow-update
           default: deny-update
       - name: allow-update
         type: step.authz_enforce
         config:
-          subject: admin@tailnet
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: authz.roles
           action: update
           permitted: true
           reason: admin:authz.roles:update granted
+      - name: upsert-role
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: |
+            INSERT INTO scenario90_role_assignments (user, role, context, scopes_json, updated_at)
+            VALUES (?, ?, ?, ?, datetime('now'))
+            ON CONFLICT(user, role, context) DO UPDATE SET
+              scopes_json = excluded.scopes_json,
+              updated_at = datetime('now')
+          params:
+            - '{{ index .steps "parse_request" "body" "user" }}'
+            - '{{ index .steps "parse_request" "body" "role" }}'
+            - '{{ index .steps "parse_request" "body" "context" }}'
+            - '{{ json (index .steps "parse_request" "body" "scopes") }}'
+      - name: fetch-role
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context, CAST(scopes_json AS BLOB) AS scopes
+            FROM scenario90_role_assignments
+            WHERE user = ? AND role = ? AND context = ?
+          params:
+            - '{{ index .steps "parse_request" "body" "user" }}'
+            - '{{ index .steps "parse_request" "body" "role" }}'
+            - '{{ index .steps "parse_request" "body" "context" }}'
+          mode: single
       - name: allow-response
         type: step.json_response
         config:
           status: 200
           body:
             updated: true
-            assignment: { _from: "steps.parse_request.body" }
+            assignment: { _from: "steps.fetch-role.row" }
             reason: { _from: "steps.allow-update.reason" }
       - name: deny-update
         type: step.authz_enforce
         config:
-          subject: non-admin
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: authz.roles
           action: update
           permitted: false
@@ -1160,21 +1879,50 @@ pipelines:
           auth_module: auth
           token_source: steps.parse_request.headers.Authorization
           subject_field: subject
-      - name: route-by-user
+      - *scenario90_create_role_table_step
+      - name: find-authz-roles-update
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ? AND context = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = ?
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "authenticate" "email" }}'
+            - admin
+            - admin:authz.roles:update
+          mode: single
+      - name: route-by-authz-roles-update
         type: step.conditional
         config:
-          field: steps.authenticate.email
+          field: steps.find-authz-roles-update.found
           routes:
-            admin@tailnet: allow-delete
+            'true': allow-delete
           default: deny-delete
       - name: allow-delete
         type: step.authz_enforce
         config:
-          subject: admin@tailnet
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: authz.roles
           action: update
           permitted: true
           reason: admin:authz.roles:update granted
+      - name: delete-role
+        type: step.db_exec
+        config:
+          database: admin-db
+          query: "DELETE FROM scenario90_role_assignments WHERE user = ? AND role = ? AND context = ?"
+          params:
+            - '{{ index .steps "parse_request" "body" "user" }}'
+            - '{{ index .steps "parse_request" "body" "role" }}'
+            - '{{ index .steps "parse_request" "body" "context" }}'
       - name: allow-response
         type: step.json_response
         config:
@@ -1186,7 +1934,7 @@ pipelines:
       - name: deny-delete
         type: step.authz_enforce
         config:
-          subject: non-admin
+          subject: '{{ index .steps "authenticate" "email" }}'
           resource: authz.roles
           action: update
           permitted: false
@@ -1206,31 +1954,120 @@ pipelines:
         path: /api/authz/enforce
         method: POST
     steps:
-      - name: parse_auth
+      - name: parse_request
         type: step.request_parse
         config:
           parse_headers: [Authorization]
+          parse_body: true
       - name: authenticate
         type: step.auth_validate
         config:
           auth_module: auth
-          token_source: steps.parse_auth.headers.Authorization
+          token_source: steps.parse_request.headers.Authorization
           subject_field: subject
-      - name: enforce
+      - *scenario90_create_role_table_step
+      - name: find-subject-match
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT 1 AS matched
+            WHERE ? = ?
+            LIMIT 1
+          params:
+            - '{{ index .steps "parse_request" "body" "subject" }}'
+            - '{{ index .steps "authenticate" "email" }}'
+          mode: single
+      - name: route-subject-match
+        type: step.conditional
+        config:
+          field: steps.find-subject-match.found
+          routes:
+            'true': find-matching-assignment
+          default: deny-spoof
+      - name: find-matching-assignment
+        type: step.db_query
+        config:
+          database: admin-db
+          query: |
+            SELECT user, role, context
+            FROM scenario90_role_assignments
+            WHERE user = ?
+              AND EXISTS (
+                SELECT 1
+                FROM json_each(scenario90_role_assignments.scopes_json)
+                WHERE value = CASE
+                  WHEN ? = 'orders' THEN 'frontend:orders:' || ?
+                  WHEN ? = 'authz.roles' THEN 'admin:authz.roles:' || ?
+                  ELSE '__scenario90_missing_scope__'
+                END
+              )
+            LIMIT 1
+          params:
+            - '{{ index .steps "parse_request" "body" "subject" }}'
+            - '{{ index .steps "parse_request" "body" "object" }}'
+            - '{{ index .steps "parse_request" "body" "action" }}'
+            - '{{ index .steps "parse_request" "body" "object" }}'
+            - '{{ index .steps "parse_request" "body" "action" }}'
+          mode: single
+      - name: route-decision
+        type: step.conditional
+        config:
+          field: steps.find-matching-assignment.found
+          routes:
+            'true': allow
+          default: deny
+      - name: allow
         type: step.authz_enforce
         config:
-          subject: admin@tailnet
-          resource: authz.roles
-          action: update
+          subject: '{{ index .steps "parse_request" "body" "subject" }}'
+          resource: '{{ index .steps "parse_request" "body" "object" }}'
+          action: '{{ index .steps "parse_request" "body" "action" }}'
           permitted: true
-          reason: scenario fixture grants admin role
+          reason: persisted role assignment grants request
       - name: respond
         type: step.json_response
         config:
           status: 200
           body:
-            subject: { _from: "steps.enforce.subject" }
-            object: { _from: "steps.enforce.resource" }
-            action: { _from: "steps.enforce.action" }
-            allowed: { _from: "steps.enforce.permitted" }
-            reason: { _from: "steps.enforce.reason" }
+            subject: { _from: "steps.parse_request.body.subject" }
+            object: { _from: "steps.parse_request.body.object" }
+            action: { _from: "steps.parse_request.body.action" }
+            allowed: true
+            reason: { _from: "steps.allow.reason" }
+      - name: deny
+        type: step.authz_enforce
+        config:
+          subject: '{{ index .steps "parse_request" "body" "subject" }}'
+          resource: '{{ index .steps "parse_request" "body" "object" }}'
+          action: '{{ index .steps "parse_request" "body" "action" }}'
+          permitted: false
+          reason: missing matching assignment
+      - name: deny-response
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            subject: { _from: "steps.parse_request.body.subject" }
+            object: { _from: "steps.parse_request.body.object" }
+            action: { _from: "steps.parse_request.body.action" }
+            allowed: false
+            reason: { _from: "steps.deny.reason" }
+      - name: deny-spoof
+        type: step.authz_enforce
+        config:
+          subject: '{{ index .steps "authenticate" "email" }}'
+          resource: '{{ index .steps "parse_request" "body" "object" }}'
+          action: '{{ index .steps "parse_request" "body" "action" }}'
+          permitted: false
+          reason: subject does not match authenticated user
+      - name: deny-spoof-response
+        type: step.json_response
+        config:
+          status: 403
+          body:
+            subject: { _from: "steps.parse_request.body.subject" }
+            object: { _from: "steps.parse_request.body.object" }
+            action: { _from: "steps.parse_request.body.action" }
+            allowed: false
+            reason: { _from: "steps.deny-spoof.reason" }

--- a/scenarios/90-admin-tailnet-demo/docker-compose.yml
+++ b/scenarios/90-admin-tailnet-demo/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       WFCTL_PLUGIN_DIR: /data/plugins
       JWT_SECRET: scenario-90-local-demo-secret-32-bytes-minimum
+      SCENARIO90_SEED_TOKEN: ${SCENARIO90_SEED_TOKEN:?SCENARIO90_SEED_TOKEN required}
     ports:
       - "127.0.0.1:18080:8080"
 

--- a/scenarios/90-admin-tailnet-demo/docker-compose.yml
+++ b/scenarios/90-admin-tailnet-demo/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     environment:
       WFCTL_PLUGIN_DIR: /data/plugins
       JWT_SECRET: scenario-90-local-demo-secret-32-bytes-minimum
-      SCENARIO90_SEED_TOKEN: ${SCENARIO90_SEED_TOKEN:?SCENARIO90_SEED_TOKEN required}
     ports:
       - "127.0.0.1:18080:8080"
 

--- a/scenarios/90-admin-tailnet-demo/seed/seed.sh
+++ b/scenarios/90-admin-tailnet-demo/seed/seed.sh
@@ -139,8 +139,12 @@ mkdir -p "$BUILD_DIR/plugins" "$BUILD_DIR/admin-ui" "$BUILD_DIR/authz-ui" "$BUIL
 if [ -z "${SCENARIO90_SEED_TOKEN:-}" ]; then
   if command -v openssl >/dev/null 2>&1; then
     SCENARIO90_SEED_TOKEN="$(openssl rand -hex 32)"
-  else
+  elif command -v uuidgen >/dev/null 2>&1; then
     SCENARIO90_SEED_TOKEN="$(uuidgen | tr '[:upper:]' '[:lower:]')-$(date +%s)"
+  elif command -v od >/dev/null 2>&1; then
+    SCENARIO90_SEED_TOKEN="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
+  else
+    SCENARIO90_SEED_TOKEN="scenario90-$(date +%s)-$$"
   fi
 fi
 export SCENARIO90_SEED_TOKEN

--- a/scenarios/90-admin-tailnet-demo/seed/seed.sh
+++ b/scenarios/90-admin-tailnet-demo/seed/seed.sh
@@ -31,12 +31,20 @@ admin_ui_dir_has_auth_gate() {
     grep -R 'Authorization' "$ui_dir" >/dev/null 2>&1
 }
 
+admin_ui_dir_has_contribution_renderers() {
+  local ui_dir="$1"
+  grep -R 'renderConfigForm' "$ui_dir" >/dev/null 2>&1 &&
+    grep -R 'workflow.admin.auth.request' "$ui_dir" >/dev/null 2>&1 &&
+    grep -R 'workflow.admin.auth.response' "$ui_dir" >/dev/null 2>&1
+}
+
 admin_repo_is_usable() {
   local repo="$1"
   [ -f "$repo/go.mod" ] &&
     [ -d "$repo/internal/ui_dist" ] &&
     ! admin_ui_dir_has_hardcoded_surfaces "$repo/internal/ui_dist" &&
-    admin_ui_dir_has_auth_gate "$repo/internal/ui_dist"
+    admin_ui_dir_has_auth_gate "$repo/internal/ui_dist" &&
+    admin_ui_dir_has_contribution_renderers "$repo/internal/ui_dist"
 }
 
 find_admin_repo() {
@@ -128,7 +136,17 @@ build_plugin() {
 BUILD_DIR="$SCENARIO_DIR/.build"
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR/plugins" "$BUILD_DIR/admin-ui" "$BUILD_DIR/authz-ui" "$BUILD_DIR/app-ui" "$BUILD_DIR/data"
+if [ -z "${SCENARIO90_SEED_TOKEN:-}" ]; then
+  if command -v openssl >/dev/null 2>&1; then
+    SCENARIO90_SEED_TOKEN="$(openssl rand -hex 32)"
+  else
+    SCENARIO90_SEED_TOKEN="$(uuidgen | tr '[:upper:]' '[:lower:]')-$(date +%s)"
+  fi
+fi
+export SCENARIO90_SEED_TOKEN
 cp "$SCENARIO_DIR/config/app.yaml" "$BUILD_DIR/app.yaml"
+awk -v token="$SCENARIO90_SEED_TOKEN" '{ gsub(/\$\{SCENARIO90_SEED_TOKEN\}/, token); print }' "$BUILD_DIR/app.yaml" > "$BUILD_DIR/app.yaml.tmp"
+mv "$BUILD_DIR/app.yaml.tmp" "$BUILD_DIR/app.yaml"
 
 require_go_module "$WORKFLOW_REPO"
 echo "Building workflow server..."
@@ -151,6 +169,11 @@ fi
 if ! admin_ui_dir_has_auth_gate "$BUILD_DIR/admin-ui"; then
   echo "ERROR: selected workflow-plugin-admin UI does not include token-aware admin loading" >&2
   echo "       Use workflow-plugin-admin with login-aware shell assets, or set PLUGIN_ADMIN_REPO explicitly." >&2
+  exit 1
+fi
+if ! admin_ui_dir_has_contribution_renderers "$BUILD_DIR/admin-ui"; then
+  echo "ERROR: selected workflow-plugin-admin UI does not render config-form surfaces or iframe auth bridge requests" >&2
+  echo "       Use workflow-plugin-admin with contribution renderer assets, or set PLUGIN_ADMIN_REPO explicitly." >&2
   exit 1
 fi
 if [ -d "$PLUGIN_AUTHZ_UI_REPO/ui/dist" ]; then
@@ -220,6 +243,8 @@ docker compose up -d
 echo "Waiting for Workflow /healthz ..."
 for i in $(seq 1 90); do
   if curl -fs http://127.0.0.1:18080/healthz >/dev/null 2>&1; then
+    curl -fsS -X POST -H "X-Scenario90-Seed-Token: $SCENARIO90_SEED_TOKEN" http://127.0.0.1:18080/api/scenario90/seed/roles >/dev/null
+    echo "Seeded baseline role assignments"
     echo "Stack ready at http://127.0.0.1:18080 (took ${i}s)"
     echo "Admin UI: http://127.0.0.1:18080/admin/"
     echo "Authz UI: http://127.0.0.1:18080/admin/authz/"

--- a/scenarios/90-admin-tailnet-demo/test/playwright.config.cjs
+++ b/scenarios/90-admin-tailnet-demo/test/playwright.config.cjs
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = {
+  testDir: path.join(__dirname, 'playwright'),
+  outputDir: path.join(__dirname, 'playwright-output'),
+  reporter: [['line']],
+  use: {
+    baseURL: process.env.BASE || 'http://127.0.0.1:18080',
+    viewport: { width: 1440, height: 960 },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+};

--- a/scenarios/90-admin-tailnet-demo/test/playwright/admin-surfaces.spec.cjs
+++ b/scenarios/90-admin-tailnet-demo/test/playwright/admin-surfaces.spec.cjs
@@ -1,0 +1,107 @@
+const { test, expect } = require('@playwright/test');
+
+async function loginAdmin(page, request, email = 'admin@tailnet', password = 'admin-password') {
+  await request.post('/api/admin/auth/register', {
+    data: { email, password, name: email.split('@')[0] },
+    failOnStatusCode: false,
+  });
+  await page.goto('/admin/');
+  await page.locator('#admin-email').fill(email);
+  await page.locator('#admin-password').fill(password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.locator('#load-status')).toContainText(/Admin tools loaded|Contributions loaded|Loading/i, { timeout: 10000 });
+}
+
+function captureConsoleErrors(page, errors) {
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+}
+
+test('Scenario 90 admin surfaces are usable and protected', async ({ page, context, request, browser }) => {
+  const consoleErrors = [];
+  captureConsoleErrors(page, consoleErrors);
+  context.on('page', (newPage) => captureConsoleErrors(newPage, consoleErrors));
+
+  await loginAdmin(page, request);
+  await expect(page.getByRole('button', { name: 'Authentication' })).toBeVisible({ timeout: 10000 });
+
+  await page.getByRole('button', { name: 'Authentication' }).click();
+  await expect(page.locator('#panel-title')).toHaveText('Authentication');
+  await expect(page.locator('#contribution-list')).toContainText('Passkey relying party ID', { timeout: 10000 });
+  await expect(page.locator('#contribution-list')).toContainText('OAuth providers');
+  await page.getByRole('button', { name: 'Validate changes' }).click();
+  await expect(page.locator('#contribution-list')).toContainText(/valid/i);
+  let activeLabels = await page.locator('button.nav-item.active').evaluateAll((nodes) => nodes.map((node) => node.textContent.trim()));
+  expect(activeLabels).toEqual(['Authentication']);
+
+  await page.getByRole('button', { name: 'Authorization' }).click();
+  await expect(page.locator('#panel-title')).toHaveText('Authorization');
+  activeLabels = await page.locator('button.nav-item.active').evaluateAll((nodes) => nodes.map((node) => node.textContent.trim()));
+  expect(activeLabels).toEqual(['Authorization']);
+
+  const frame = page.frameLocator('#contribution-list iframe').first();
+  await expect(frame.getByText('Authz Policy Manager')).toBeVisible({ timeout: 10000 });
+  await expect(frame.locator('body')).not.toContainText('Not authorized');
+  await expect(frame.locator('body')).toContainText(/RBAC|Role Assignments|Provider Overview/i);
+  await frame.getByRole('button', { name: 'Overview' }).click();
+  await expect(frame.locator('body')).toContainText('RBAC');
+  await expect(frame.getByRole('button', { name: 'ABAC' })).toHaveCount(0);
+  await expect(frame.getByRole('button', { name: 'ReBAC' })).toHaveCount(0);
+  await frame.getByRole('button', { name: 'RBAC' }).click();
+  await expect(frame.getByRole('button', { name: 'Add Role' })).toBeEnabled();
+  await frame.getByLabel('User', { exact: true }).selectOption('app-user@tailnet');
+  await frame.getByLabel('Role', { exact: true }).selectOption('support');
+  await frame.locator('form.rule-form select').nth(2).selectOption('admin');
+  await frame.locator('label.scope-option').filter({ hasText: 'admin:authz.roles:read' }).locator('input').check();
+  await frame.getByRole('button', { name: 'Add Role' }).click();
+  await expect(frame.locator('body')).toContainText('admin:authz.roles:read');
+  const adminToken = await page.evaluate(() => window.localStorage.getItem('workflow.admin.token'));
+  const rolesAfterWrite = await request.get('/api/authz/roles', {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  });
+  expect(rolesAfterWrite.ok()).toBeTruthy();
+  const roleRows = await rolesAfterWrite.json();
+  expect(roleRows).toEqual(expect.arrayContaining([
+    expect.objectContaining({
+      user: 'app-user@tailnet',
+      role: 'support',
+      context: 'admin',
+      scopes: expect.arrayContaining(['admin:authz.roles:read']),
+    }),
+  ]));
+  await frame.getByRole('button', { name: 'Simulator' }).click();
+  await expect(frame.locator('body')).toContainText(/Authorize|Subject|Object/i);
+  await frame.getByRole('button', { name: 'Audit' }).click();
+  await expect(frame.locator('body')).toContainText('Unavailable');
+
+  const direct = await context.newPage();
+  await direct.goto('/admin/authz/');
+  await expect(direct.getByText('Authentication Required')).toBeVisible({ timeout: 10000 });
+  await expect(direct.locator('body')).toContainText('Sign in through Workflow Admin');
+  await expect(direct.locator('body')).not.toContainText('Authz Policy Manager');
+  await expect(direct.locator('body')).not.toContainText('Role Assignments');
+  await direct.close();
+
+  await request.post('/api/app/auth/register', {
+    data: { email: 'app-user@tailnet', password: 'app-password', name: 'Support User' },
+    failOnStatusCode: false,
+  });
+  const supportContext = await browser.newContext({ baseURL: 'http://127.0.0.1:18080' });
+  supportContext.on('page', (newPage) => captureConsoleErrors(newPage, consoleErrors));
+  const supportPage = await supportContext.newPage();
+  await loginAdmin(supportPage, request, 'app-user@tailnet', 'app-password');
+  await expect(supportPage.getByRole('button', { name: 'Authorization' })).toBeVisible({ timeout: 10000 });
+  await expect(supportPage.getByRole('button', { name: 'Authentication' })).toHaveCount(0);
+  await supportPage.getByRole('button', { name: 'Authorization' }).click();
+  const supportFrame = supportPage.frameLocator('#contribution-list iframe').first();
+  await expect(supportFrame.getByText('Authz Policy Manager')).toBeVisible({ timeout: 10000 });
+  await expect(supportFrame.locator('body')).not.toContainText('Not authorized');
+  await supportFrame.getByRole('button', { name: 'RBAC' }).click();
+  await expect(supportFrame.getByRole('button', { name: 'Add Role' })).toBeDisabled();
+  await expect(supportFrame.locator('body')).toContainText('updating requires admin:authz.roles:update');
+  await supportContext.close();
+
+  expect(consoleErrors.filter((text) => !text.includes('favicon'))).toEqual([]);
+});

--- a/scenarios/90-admin-tailnet-demo/test/playwright/admin-surfaces.spec.cjs
+++ b/scenarios/90-admin-tailnet-demo/test/playwright/admin-surfaces.spec.cjs
@@ -57,7 +57,11 @@ test('Scenario 90 admin surfaces are usable and protected', async ({ page, conte
   await frame.locator('label.scope-option').filter({ hasText: 'admin:authz.roles:read' }).locator('input').check();
   await frame.getByRole('button', { name: 'Add Role' }).click();
   await expect(frame.locator('body')).toContainText('admin:authz.roles:read');
-  const adminToken = await page.evaluate(() => window.localStorage.getItem('workflow.admin.token'));
+  const adminToken = await page.evaluate(() => {
+    const shell = document.querySelector('[data-token-storage-key]');
+    const storageKey = shell?.dataset?.tokenStorageKey || 'workflow.admin.token';
+    return window.localStorage.getItem(storageKey);
+  });
   const rolesAfterWrite = await request.get('/api/authz/roles', {
     headers: { Authorization: `Bearer ${adminToken}` },
   });

--- a/scenarios/90-admin-tailnet-demo/test/run-playwright.sh
+++ b/scenarios/90-admin-tailnet-demo/test/run-playwright.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLAYWRIGHT_PREFIX="${PLAYWRIGHT_PREFIX:-/tmp/scenario90-playwright-cli}"
 
+mkdir -p "$PLAYWRIGHT_PREFIX"
+
 if [ ! -x "$PLAYWRIGHT_PREFIX/node_modules/.bin/playwright" ]; then
   npm --prefix "$PLAYWRIGHT_PREFIX" install --silent @playwright/test
 fi

--- a/scenarios/90-admin-tailnet-demo/test/run-playwright.sh
+++ b/scenarios/90-admin-tailnet-demo/test/run-playwright.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLAYWRIGHT_PREFIX="${PLAYWRIGHT_PREFIX:-/tmp/scenario90-playwright-cli}"
+
+if [ ! -x "$PLAYWRIGHT_PREFIX/node_modules/.bin/playwright" ]; then
+  npm --prefix "$PLAYWRIGHT_PREFIX" install --silent @playwright/test
+fi
+
+npx --prefix "$PLAYWRIGHT_PREFIX" playwright install chromium
+
+export NODE_PATH
+NODE_PATH="$(npm root --prefix "$PLAYWRIGHT_PREFIX")"
+
+npx --prefix "$PLAYWRIGHT_PREFIX" playwright test --config="$SCRIPT_DIR/playwright.config.cjs" "$@"

--- a/scenarios/90-admin-tailnet-demo/test/run.sh
+++ b/scenarios/90-admin-tailnet-demo/test/run.sh
@@ -40,6 +40,11 @@ if find "$SCENARIO_DIR" -type f \( -name '*.py' -o -name '*.pyc' \) | grep -q .;
 else
   pass "Scenario has no Python app harness artifacts"
 fi
+if grep -A28 'name: admin-authz-contribution' "$SCENARIO_DIR/config/app.yaml" | grep -q 'type: step.authz_admin_contribution'; then
+  pass "Authz admin contribution comes from authz UI plugin step"
+else
+  fail "Authz admin contribution must come from authz UI plugin step"
+fi
 
 "$SCENARIO_DIR/seed/seed.sh"
 
@@ -91,6 +96,19 @@ else
   fail "Anonymous authz roles API expected 401, got $unauth_authz_code"
 fi
 
+unauth_seed_code="$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/scenario90/seed/roles" || echo "000")"
+if [ "$unauth_seed_code" = "403" ]; then
+  pass "Anonymous role seed endpoint is forbidden"
+else
+  fail "Anonymous role seed endpoint expected 403, got $unauth_seed_code"
+fi
+committed_seed_code="$(curl -s -o /dev/null -w "%{http_code}" -X POST -H 'X-Scenario90-Seed-Token: scenario90-local-seed' "$BASE/api/scenario90/seed/roles" || echo "000")"
+if [ "$committed_seed_code" = "403" ]; then
+  pass "Committed sample seed token is not accepted"
+else
+  fail "Committed sample seed token expected 403, got $committed_seed_code"
+fi
+
 register_body="$(curl -sfS -X POST "$BASE/api/admin/auth/register" \
   -H "content-type: application/json" \
   -d '{"email":"admin@tailnet","password":"admin-password","name":"Scenario Admin"}' 2>/dev/null || true)"
@@ -116,6 +134,7 @@ contains "$contribs" '"id":"authz-roles"' "Admin plugin registered authz contrib
 contains "$contribs" '"id":"auth-config"' "Admin plugin registered auth contribution from auth plugin"
 contains "$contribs" '"render_mode":"config-form"' "Auth contribution uses generic config form render mode"
 contains "$contribs" '"render_mode":"iframe"' "Admin contribution uses pluggable iframe render mode"
+contains "$contribs" '"admin:authz.roles:update"' "Admin contribution grant bridge includes authz update scope"
 
 catalog="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/admin/auth/providers")"
 json_len_at_least "$catalog" '.providers' 9 "Auth provider catalog includes composed providers"
@@ -134,9 +153,46 @@ else
   pass "Auth config does not echo provider secrets"
 fi
 
+delegated_register="$(curl -sfS -X POST "$BASE/api/admin/auth/register" \
+  -H "content-type: application/json" \
+  -d '{"email":"delegated-admin@tailnet","password":"delegated-password","name":"Delegated Admin"}' 2>/dev/null || true)"
+delegated_token="$(jq -r '.token // .access_token // empty' <<<"$delegated_register" 2>/dev/null || true)"
+if [ -z "$delegated_token" ]; then
+  delegated_login="$(curl -sfS -X POST "$BASE/api/admin/auth/login" \
+    -H "content-type: application/json" \
+    -d '{"email":"delegated-admin@tailnet","password":"delegated-password"}' 2>/dev/null || true)"
+  delegated_token="$(jq -r '.token // .access_token // empty' <<<"$delegated_login" 2>/dev/null || true)"
+fi
+if [ -n "$delegated_token" ]; then
+  pass "Delegated admin login returns JWT token"
+else
+  fail "Delegated admin login did not return a JWT token"
+fi
+DELEGATED_AUTH_HEADER="Authorization: Bearer $delegated_token"
+delegated_auth_config="$(curl -fsS -H "$DELEGATED_AUTH_HEADER" "$BASE/api/admin/auth/config")"
+contains "$delegated_auth_config" '"groups"' "Auth config read is authorized by admin scope, not hardcoded identity"
+
 validate_config="$(curl -fsS -H "$AUTH_HEADER" -H 'content-type: application/json' -d '{"desired_config":{"environment":"production","password_auth_enabled":true}}' "$BASE/api/admin/auth/config/validate")"
 contains "$validate_config" '"valid":false' "Auth config validation rejects unsafe production password login"
 contains "$validate_config" 'password auth cannot be enabled in production' "Auth config validation returns plugin diagnostic"
+delegated_validate_code="$(curl -s -o /tmp/scenario90-delegated-validate.json -w "%{http_code}" -H "$DELEGATED_AUTH_HEADER" -H 'content-type: application/json' -d '{"desired_config":{"environment":"development"}}' "$BASE/api/admin/auth/config/validate")"
+if [ "$delegated_validate_code" = "403" ]; then
+  pass "Delegated read-only auth admin cannot validate config without update scope"
+else
+  fail "Delegated auth config validate expected 403, got $delegated_validate_code"
+fi
+delegated_scopes_code="$(curl -s -o /tmp/scenario90-delegated-authz-scopes.json -w "%{http_code}" -H "$DELEGATED_AUTH_HEADER" "$BASE/api/authz/scopes")"
+if [ "$delegated_scopes_code" = "403" ]; then
+  pass "Delegated auth admin cannot read authz metadata without authz read scope"
+else
+  fail "Delegated authz scopes expected 403, got $delegated_scopes_code"
+fi
+delegated_caps_code="$(curl -s -o /tmp/scenario90-delegated-authz-caps.json -w "%{http_code}" -H "$DELEGATED_AUTH_HEADER" "$BASE/api/authz/capabilities")"
+if [ "$delegated_caps_code" = "403" ]; then
+  pass "Delegated auth admin cannot read authz capabilities without authz read scope"
+else
+  fail "Delegated authz capabilities expected 403, got $delegated_caps_code"
+fi
 
 for provider in auth0 entra ory-kratos ory-hydra ory-polis scalekit; do
   body="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/admin/auth/providers/$provider")"
@@ -157,12 +213,14 @@ contains "$add_role" '"updated":true' "Authz role update endpoint accepts admin 
 
 caps="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/authz/capabilities")"
 contains "$caps" '"mode":"rbac"' "Authz capabilities report RBAC"
-contains "$caps" '"mode":"abac"' "Authz capabilities report ABAC"
-contains "$caps" '"mode":"rebac"' "Authz capabilities report ReBAC"
+contains "$caps" '"mode":"abac"' "Authz capabilities disclose ABAC availability"
+contains "$caps" '"configured":false' "Authz capabilities mark unsupported modes unconfigured"
+contains "$caps" 'does not expose ABAC policy routes' "Authz capabilities explain unsupported ABAC routes"
+contains "$caps" 'does not expose ReBAC relation routes' "Authz capabilities explain unsupported ReBAC routes"
 
 enforce="$(curl -fsS -H "$AUTH_HEADER" -H 'content-type: application/json' -d '{"subject":"admin@tailnet","object":"authz.roles","action":"update"}' "$BASE/api/authz/enforce")"
 contains "$enforce" '"allowed":true' "Authz UI plugin enforce step permits expected action"
-contains "$enforce" '"reason":"scenario fixture grants admin role"' "Authz enforce response comes from plugin step config"
+contains "$enforce" '"reason":"persisted role assignment grants request"' "Authz enforce response comes from persisted role assignment"
 
 support_register="$(curl -sfS -X POST "$BASE/api/app/auth/register" \
   -H "content-type: application/json" \
@@ -180,6 +238,23 @@ else
   fail "Primary app support login did not return a JWT token"
 fi
 SUPPORT_AUTH_HEADER="Authorization: Bearer $support_token"
+
+viewer_register="$(curl -sfS -X POST "$BASE/api/app/auth/register" \
+  -H "content-type: application/json" \
+  -d '{"email":"viewer@tailnet","password":"viewer-password","name":"Viewer User"}' 2>/dev/null || true)"
+viewer_token="$(jq -r '.token // .access_token // empty' <<<"$viewer_register" 2>/dev/null || true)"
+if [ -z "$viewer_token" ]; then
+  viewer_login="$(curl -sfS -X POST "$BASE/api/app/auth/login" \
+    -H "content-type: application/json" \
+    -d '{"email":"viewer@tailnet","password":"viewer-password"}' 2>/dev/null || true)"
+  viewer_token="$(jq -r '.token // .access_token // empty' <<<"$viewer_login" 2>/dev/null || true)"
+fi
+if [ -n "$viewer_token" ]; then
+  pass "Primary app viewer login returns JWT token"
+else
+  fail "Primary app viewer login did not return a JWT token"
+fi
+VIEWER_AUTH_HEADER="Authorization: Bearer $viewer_token"
 
 support_access="$(curl -fsS -H "$SUPPORT_AUTH_HEADER" "$BASE/api/app/access")"
 contains "$support_access" '"role":"support"' "SPA access projection identifies support role"
@@ -199,6 +274,77 @@ else
   fail "Support update expected 403, got $support_update_code"
 fi
 contains "$(cat /tmp/scenario90-support-update.json)" 'missing frontend:orders:update' "Support update denial explains missing scope"
+
+support_auth_config_code="$(curl -s -o /tmp/scenario90-support-auth-config.json -w "%{http_code}" -H "$SUPPORT_AUTH_HEADER" "$BASE/api/admin/auth/config")"
+if [ "$support_auth_config_code" = "403" ]; then
+  pass "Support cannot read admin auth config without admin auth scope"
+else
+  fail "Support auth config expected 403, got $support_auth_config_code"
+fi
+support_auth_catalog_code="$(curl -s -o /tmp/scenario90-support-auth-catalog.json -w "%{http_code}" -H "$SUPPORT_AUTH_HEADER" "$BASE/api/admin/auth/providers")"
+if [ "$support_auth_catalog_code" = "403" ]; then
+  pass "Support cannot read admin auth provider catalog without admin auth scope"
+else
+  fail "Support auth provider catalog expected 403, got $support_auth_catalog_code"
+fi
+support_validate_code="$(curl -s -o /tmp/scenario90-support-auth-validate.json -w "%{http_code}" -H "$SUPPORT_AUTH_HEADER" -H 'content-type: application/json' -d '{"desired_config":{"environment":"development"}}' "$BASE/api/admin/auth/config/validate")"
+if [ "$support_validate_code" = "403" ]; then
+  pass "Support cannot validate admin auth config without admin auth update scope"
+else
+  fail "Support auth config validate expected 403, got $support_validate_code"
+fi
+viewer_roles_code="$(curl -s -o /tmp/scenario90-viewer-roles.json -w "%{http_code}" -H "$VIEWER_AUTH_HEADER" "$BASE/api/authz/roles")"
+if [ "$viewer_roles_code" = "403" ]; then
+  pass "Viewer cannot read authz role assignments without admin authz read scope"
+else
+  fail "Viewer authz roles expected 403, got $viewer_roles_code"
+fi
+
+arbitrary_enforce="$(curl -fsS -H "$VIEWER_AUTH_HEADER" -H 'content-type: application/json' -d '{"subject":"viewer@tailnet","object":"orders","action":"delete"}' "$BASE/api/authz/enforce")"
+contains "$arbitrary_enforce" '"subject":"viewer@tailnet"' "Authz enforce echoes requested subject"
+contains "$arbitrary_enforce" '"object":"orders"' "Authz enforce echoes requested object"
+contains "$arbitrary_enforce" '"action":"delete"' "Authz enforce echoes requested action"
+contains "$arbitrary_enforce" '"allowed":false' "Authz enforce denies ungranted arbitrary action"
+spoof_enforce_code="$(curl -s -o /tmp/scenario90-spoof-enforce.json -w "%{http_code}" -H "$SUPPORT_AUTH_HEADER" -H 'content-type: application/json' -d '{"subject":"admin@tailnet","object":"authz.roles","action":"update"}' "$BASE/api/authz/enforce")"
+if [ "$spoof_enforce_code" = "403" ]; then
+  pass "Authz enforce rejects spoofed subject simulation"
+else
+  fail "Authz enforce spoof expected 403, got $spoof_enforce_code"
+fi
+contains "$(cat /tmp/scenario90-spoof-enforce.json)" 'subject does not match authenticated user' "Spoofed enforce denial explains subject mismatch"
+
+new_role="$(curl -fsS -H "$AUTH_HEADER" -H 'content-type: application/json' -d '{"user":"new@tailnet","role":"auditor","context":"frontend","scopes":["frontend:orders:read"]}' "$BASE/api/authz/roles")"
+contains "$new_role" '"updated":true' "Authz role update accepts new persisted assignment"
+roles_after_add="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/authz/roles")"
+contains "$roles_after_add" '"new@tailnet"' "Authz roles endpoint reflects newly added assignment"
+new_register="$(curl -sfS -X POST "$BASE/api/app/auth/register" \
+  -H "content-type: application/json" \
+  -d '{"email":"new@tailnet","password":"new-password","name":"New Auditor"}' 2>/dev/null || true)"
+new_token="$(jq -r '.token // .access_token // empty' <<<"$new_register" 2>/dev/null || true)"
+if [ -z "$new_token" ]; then
+  new_login="$(curl -sfS -X POST "$BASE/api/app/auth/login" \
+    -H "content-type: application/json" \
+    -d '{"email":"new@tailnet","password":"new-password"}' 2>/dev/null || true)"
+  new_token="$(jq -r '.token // .access_token // empty' <<<"$new_login" 2>/dev/null || true)"
+fi
+if [ -n "$new_token" ]; then
+  pass "New persisted-role user login returns JWT token"
+else
+  fail "New persisted-role user login did not return a JWT token"
+fi
+NEW_AUTH_HEADER="Authorization: Bearer $new_token"
+new_enforce="$(curl -fsS -H "$NEW_AUTH_HEADER" -H 'content-type: application/json' -d '{"subject":"new@tailnet","object":"orders","action":"read"}' "$BASE/api/authz/enforce")"
+contains "$new_enforce" '"allowed":true' "Authz enforce honors newly added persisted assignment"
+delete_role="$(curl -fsS -X DELETE -H "$AUTH_HEADER" -H 'content-type: application/json' -d '{"user":"new@tailnet","role":"auditor","context":"frontend"}' "$BASE/api/authz/roles")"
+contains "$delete_role" '"deleted":true' "Authz role delete accepts persisted assignment"
+roles_after_delete="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/authz/roles")"
+if grep -q '"new@tailnet"' <<<"$roles_after_delete"; then
+  fail "Authz roles endpoint still includes deleted assignment"
+else
+  pass "Authz roles endpoint removes deleted assignment"
+fi
+new_enforce_after_delete="$(curl -fsS -H "$NEW_AUTH_HEADER" -H 'content-type: application/json' -d '{"subject":"new@tailnet","object":"orders","action":"read"}' "$BASE/api/authz/enforce")"
+contains "$new_enforce_after_delete" '"allowed":false' "Authz enforce reflects deleted persisted assignment"
 
 admin_app_access="$(curl -fsS -H "$AUTH_HEADER" "$BASE/api/app/access")"
 contains "$admin_app_access" '"role":"admin"' "SPA access projection identifies admin role"


### PR DESCRIPTION
## Summary
- Turns Scenario 90 into a runnable Workflow app + admin example protected by authn/authz, with no committed seed secret and with authz metadata endpoints authorization-gated.
- Uses real admin/auth/authz plugin contribution steps for the admin nav and marks unsupported ABAC/ReBAC modes as unavailable instead of pretending routes exist.
- Adds shell and Playwright coverage for admin navigation, auth iframe bridge, RBAC write behavior, direct-route protection, delegated admin usability, and plugin-surface authorization.

## Verification
- `wfctl validate --skip-unknown-types scenarios/90-admin-tailnet-demo/config/app.yaml`
- `PLUGIN_ADMIN_REPO=/Users/jon/workspace/workflow-plugin-admin/.worktrees/admin-shell-auth-gate PLUGIN_AUTHZ_UI_REPO=/Users/jon/workspace/workflow-plugin-authz-ui/.worktrees/authz-ui-admin-bridge ./test/run.sh` -> `PASS=96 FAIL=0`
- `PLAYWRIGHT_PREFIX=/tmp/scenario90-playwright-codex ./scenarios/90-admin-tailnet-demo/test/run-playwright.sh` -> `1 passed`

## Related
- Filed workflow validator follow-up for YAML boolean edge case: https://github.com/GoCodeAlone/workflow/issues/809