### PR TITLE
Bump workflow to v0.73.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/GoCodeAlone/workflow v0.72.0
+	github.com/GoCodeAlone/workflow v0.73.0
 	github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0 h1:zoWioqUvuNNDfnjHA1s
 github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0/go.mod h1:GDU/jsD6AddmXKedj0wZwieUIaQsTBSGMzuj+XHXMrw=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0 h1:+2M/ecyCxDiXfJM4ibcERuu/BBeIbLTQNcVgRsllR64=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0/go.mod h1:tlVH1mA5yuU8CB7R7+HXIRaBixZoNid6h+5tew5u3FU=
-github.com/GoCodeAlone/workflow v0.72.0 h1:h8t3NKqCGyTiK5uiaBcpqx3P9Jkz78OMQ3fbRvS7ong=
-github.com/GoCodeAlone/workflow v0.72.0/go.mod h1:i/9ZTfR8YYlmr0+hvIZi4cYw7SxzkQRLlzYQCrRD/2k=
+github.com/GoCodeAlone/workflow v0.73.0 h1:hi8PuYujNhcMQ5H/+6e0nAPvmDdjPPzmX7nqnsMMm1k=
+github.com/GoCodeAlone/workflow v0.73.0/go.mod h1:i/9ZTfR8YYlmr0+hvIZi4cYw7SxzkQRLlzYQCrRD/2k=
 github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1 h1:NPdPpSc3PjYJ5Xzu0YKitMPqrnLB3DW5/pvKFXNHxTM=
 github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1/go.mod h1:vEqwFF4T/U9OVxbW8gfFFvkA3cMOqX918FBXAx3QaFY=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=


### PR DESCRIPTION
## Summary
- bump `github.com/GoCodeAlone/workflow` from `v0.72.0` to `v0.73.0`
- run `GOWORK=off go mod tidy`

## Verification
- `GOWORK=off go test ./...`