### PR TITLE
feat: add control-plane descriptor scenario

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/GoCodeAlone/modular/modules/eventbus/v2 v2.10.0 // indirect
 	github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0 // indirect
 	github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0 // indirect
+	github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0 // indirect
 	github.com/GoCodeAlone/yaegi v0.17.2 // indirect
 	github.com/IBM/sarama v1.47.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/GoCodeAlone/workflow v0.80.2
+	github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0
 	github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
@@ -23,7 +24,6 @@ require (
 	github.com/GoCodeAlone/modular/modules/eventbus/v2 v2.10.0 // indirect
 	github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0 // indirect
 	github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0 // indirect
-	github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0 // indirect
 	github.com/GoCodeAlone/yaegi v0.17.2 // indirect
 	github.com/IBM/sarama v1.47.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0 h1:+2M/ecyCxDiXfJ
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0/go.mod h1:tlVH1mA5yuU8CB7R7+HXIRaBixZoNid6h+5tew5u3FU=
 github.com/GoCodeAlone/workflow v0.80.2 h1:XACYtDQWnnSd55VpaaW4eOjxZrwVWZdvAFVTmHrym30=
 github.com/GoCodeAlone/workflow v0.80.2/go.mod h1:jWDYmLQYGV1eCNTzAWD/IPMYm3C8LqdMwabPw4K3RR4=
+github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0 h1:XtogtQXVBING2iu5jQGzfubi9rOes/erVWH5uwiPsok=
+github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0/go.mod h1:2c3Ow7rncEZttzq3XddC+mTD0x5CBE4TdPdvbnH4iYk=
 github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1 h1:NPdPpSc3PjYJ5Xzu0YKitMPqrnLB3DW5/pvKFXNHxTM=
 github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1/go.mod h1:vEqwFF4T/U9OVxbW8gfFFvkA3cMOqX918FBXAx3QaFY=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=

--- a/scenarios.json
+++ b/scenarios.json
@@ -1227,7 +1227,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-06-12T20:25:33.607607Z",
+      "lastTested": "2026-06-12T20:32:38.850782Z",
       "lastResult": "pass",
       "testCount": 8,
       "passCount": 8,
@@ -1237,5 +1237,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-06-12T20:25:33.607607Z"
+  "lastUpdated": "2026-06-12T20:32:38.850782Z"
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1222,6 +1222,20 @@
       "passCount": 0,
       "failCount": 0,
       "blockers": []
+    },
+    "103-control-plane-descriptors": {
+      "status": "passed",
+      "namespace": "local",
+      "deployed": false,
+      "lastTested": "2026-06-12T20:25:33.607607Z",
+      "lastResult": "pass",
+      "testCount": 8,
+      "passCount": 8,
+      "failCount": 0,
+      "localOnly": true,
+      "notes": "Validates committed control-plane descriptor, audit envelope, and registration artifacts through released workflow-plugin-control-plane protobuf validators; rejects raw URL, secret ref, raw actor identifier, and stale provenance fixtures without introducing a runtime endpoint.",
+      "blockers": []
     }
-  }
+  },
+  "lastUpdated": "2026-06-12T20:25:33.607607Z"
 }

--- a/scenarios/103-control-plane-descriptors/bundles/invalid/raw-actor-handle.json
+++ b/scenarios/103-control-plane-descriptors/bundles/invalid/raw-actor-handle.json
@@ -1,0 +1,19 @@
+{
+  "kind": "audit_envelope",
+  "payload": {
+    "protocolVersion": "control-plane.v1alpha1",
+    "envelopeId": "evt-scenario-103-raw-actor",
+    "kind": "audit",
+    "tenantHandle": "opaque-tenant-s103",
+    "actorHandle": "operator@example.test",
+    "resourceHandle": "opaque-resource-workload",
+    "correlationId": "corr-scenario-103",
+    "occurredAtUnixNano": 1000,
+    "observedAtUnixNano": 2000,
+    "retention": {
+      "redactionState": "active",
+      "retentionExpiresAtUnixNano": 9000,
+      "correlationRekeyId": "rekey-scenario-103"
+    }
+  }
+}

--- a/scenarios/103-control-plane-descriptors/bundles/invalid/raw-route-url.json
+++ b/scenarios/103-control-plane-descriptors/bundles/invalid/raw-route-url.json
@@ -1,0 +1,12 @@
+{
+  "kind": "route_action_descriptor",
+  "payload": {
+    "protocolVersion": "control-plane.v1alpha1",
+    "descriptorId": "descriptor.bad.raw.route",
+    "operationId": "bad_route",
+    "routeHandle": "https://workflow-compute.example.test/admin",
+    "authClassRef": "authclass://workflow-scenarios/103/operator",
+    "auditClassRef": "auditclass://workflow-scenarios/103/workload-submit",
+    "inputSchemaDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+}

--- a/scenarios/103-control-plane-descriptors/bundles/invalid/secret-render-ref.json
+++ b/scenarios/103-control-plane-descriptors/bundles/invalid/secret-render-ref.json
@@ -1,0 +1,20 @@
+{
+  "kind": "route_action_descriptor",
+  "payload": {
+    "protocolVersion": "control-plane.v1alpha1",
+    "descriptorId": "descriptor.bad.secret.render",
+    "operationId": "bad_secret",
+    "routeHandle": "route://workflow-scenarios/103/product-capture/submit",
+    "authClassRef": "authclass://workflow-scenarios/103/operator",
+    "auditClassRef": "auditclass://workflow-scenarios/103/workload-submit",
+    "inputSchemaDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "admin": {
+      "resourceRef": "resource://workflow-scenarios/103/product-capture",
+      "actionClassRef": "actionclass://workflow-scenarios/103/submit",
+      "riskRef": "risk://workflow-scenarios/103/provider-workload",
+      "severityRef": "severity://workflow-scenarios/103/standard",
+      "permissionExplanationTemplateRef": "template://workflow-scenarios/103/operator-permission",
+      "renderRef": "secret://workflow-scenarios/103/admin-token"
+    }
+  }
+}

--- a/scenarios/103-control-plane-descriptors/bundles/invalid/stale-registration.json
+++ b/scenarios/103-control-plane-descriptors/bundles/invalid/stale-registration.json
@@ -1,0 +1,20 @@
+{
+  "kind": "descriptor_registration",
+  "payload": {
+    "protocolVersion": "control-plane.v1alpha1",
+    "descriptorDigest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "schemaDigest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "pluginId": "workflow-plugin-product-capture",
+    "pluginVersion": "v0.1.18",
+    "pluginPackageDigest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "signingRootRef": "trustroot://workflow-scenarios/103/control-plane",
+    "provenanceSource": "provenance://github/release/workflow-plugin-product-capture",
+    "allowlistEpoch": 3,
+    "downgradeFloorVersion": "v0.1.18",
+    "revocationFreshUntilUnixNano": 1500,
+    "fetchedAtUnixNano": 1000,
+    "validatedAtUnixNano": 2000,
+    "parserCompatibilityVersion": "v1",
+    "trustRootGeneration": 2
+  }
+}

--- a/scenarios/103-control-plane-descriptors/bundles/valid/audit-envelope.json
+++ b/scenarios/103-control-plane-descriptors/bundles/valid/audit-envelope.json
@@ -1,0 +1,19 @@
+{
+  "kind": "audit_envelope",
+  "payload": {
+    "protocolVersion": "control-plane.v1alpha1",
+    "envelopeId": "evt-scenario-103-accepted",
+    "kind": "audit",
+    "tenantHandle": "opaque-tenant-s103",
+    "actorHandle": "opaque-actor-operator",
+    "resourceHandle": "opaque-resource-workload",
+    "correlationId": "corr-scenario-103",
+    "occurredAtUnixNano": 1000,
+    "observedAtUnixNano": 2000,
+    "retention": {
+      "redactionState": "active",
+      "retentionExpiresAtUnixNano": 9000,
+      "correlationRekeyId": "rekey-scenario-103"
+    }
+  }
+}

--- a/scenarios/103-control-plane-descriptors/bundles/valid/descriptor-registration.json
+++ b/scenarios/103-control-plane-descriptors/bundles/valid/descriptor-registration.json
@@ -1,0 +1,20 @@
+{
+  "kind": "descriptor_registration",
+  "payload": {
+    "protocolVersion": "control-plane.v1alpha1",
+    "descriptorDigest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "schemaDigest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "pluginId": "workflow-plugin-product-capture",
+    "pluginVersion": "v0.1.18",
+    "pluginPackageDigest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "signingRootRef": "trustroot://workflow-scenarios/103/control-plane",
+    "provenanceSource": "provenance://github/release/workflow-plugin-product-capture",
+    "allowlistEpoch": 3,
+    "downgradeFloorVersion": "v0.1.18",
+    "revocationFreshUntilUnixNano": 9000,
+    "fetchedAtUnixNano": 1000,
+    "validatedAtUnixNano": 2000,
+    "parserCompatibilityVersion": "v1",
+    "trustRootGeneration": 2
+  }
+}

--- a/scenarios/103-control-plane-descriptors/bundles/valid/route-action.json
+++ b/scenarios/103-control-plane-descriptors/bundles/valid/route-action.json
@@ -9,7 +9,7 @@
     "auditClassRef": "auditclass://workflow-scenarios/103/workload-submit",
     "inputSchemaDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "outputSchemaDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "presentationRef": "presentation://workflow-scenarios/103/admin/product-capture",
+    "presentationRef": "render://workflow-scenarios/103/admin/product-capture",
     "providerHandoff": {
       "providerPluginId": "workflow-plugin-product-capture",
       "providerPluginVersion": "v0.1.18",

--- a/scenarios/103-control-plane-descriptors/bundles/valid/route-action.json
+++ b/scenarios/103-control-plane-descriptors/bundles/valid/route-action.json
@@ -1,0 +1,31 @@
+{
+  "kind": "route_action_descriptor",
+  "payload": {
+    "protocolVersion": "control-plane.v1alpha1",
+    "descriptorId": "descriptor.wfcompute.product.capture",
+    "operationId": "product_capture_submit",
+    "routeHandle": "route://workflow-scenarios/103/product-capture/submit",
+    "authClassRef": "authclass://workflow-scenarios/103/operator",
+    "auditClassRef": "auditclass://workflow-scenarios/103/workload-submit",
+    "inputSchemaDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "outputSchemaDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "presentationRef": "presentation://workflow-scenarios/103/admin/product-capture",
+    "providerHandoff": {
+      "providerPluginId": "workflow-plugin-product-capture",
+      "providerPluginVersion": "v0.1.18",
+      "capabilityId": "product-capture-browser",
+      "capabilityVersion": "v1",
+      "inputSchemaDigest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "actionNonce": "scenario-103-nonce",
+      "idempotencyKey": "scenario-103-idem"
+    },
+    "admin": {
+      "resourceRef": "resource://workflow-scenarios/103/product-capture",
+      "actionClassRef": "actionclass://workflow-scenarios/103/submit",
+      "riskRef": "risk://workflow-scenarios/103/provider-workload",
+      "severityRef": "severity://workflow-scenarios/103/standard",
+      "permissionExplanationTemplateRef": "template://workflow-scenarios/103/operator-permission",
+      "renderRef": "render://workflow-scenarios/103/form/product-capture"
+    }
+  }
+}

--- a/scenarios/103-control-plane-descriptors/scenario.yaml
+++ b/scenarios/103-control-plane-descriptors/scenario.yaml
@@ -22,4 +22,4 @@ tags:
   - control-plane
   - descriptors
   - plugin-boundary
-  - local
+  - local-only

--- a/scenarios/103-control-plane-descriptors/scenario.yaml
+++ b/scenarios/103-control-plane-descriptors/scenario.yaml
@@ -1,0 +1,25 @@
+name: Control Plane Descriptor Bundles
+id: "103-control-plane-descriptors"
+category: C
+description: |
+  Local-only proof that product-neutral control-plane descriptor artifacts cross
+  the plugin-to-host boundary through real public contracts.
+
+  The scenario stores descriptor, audit envelope, and descriptor-registration
+  artifacts as JSON protobuf payloads. The validator imports released
+  workflow-plugin-control-plane packages, unmarshals the fixture artifacts into
+  generated protobuf messages, and calls the public descriptor/envelope/registry
+  validators.
+
+  Valid fixtures must pass, while invalid fixtures with raw network URLs,
+  secret refs, raw actor identifiers, and stale provenance must be rejected.
+  This intentionally proves descriptor bundle shape without creating a new
+  Workflow runtime endpoint or copying schema checks into the scenario.
+components:
+  - workflow-plugin-control-plane (descriptors/envelopes/registry validators)
+status: testable
+tags:
+  - control-plane
+  - descriptors
+  - plugin-boundary
+  - local

--- a/scenarios/103-control-plane-descriptors/test/run.sh
+++ b/scenarios/103-control-plane-descriptors/test/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Scenario 103 — Control-plane descriptor bundle proof.
+#
+# Runs the real Go validator against committed descriptor bundle artifacts.
+# PASS/FAIL lines are produced from validator execution, not static fixtures.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCENARIO_DIR="$(dirname "$SCRIPT_DIR")"
+VALIDATOR_DIR="$SCENARIO_DIR/validator"
+VALID_DIR="$SCENARIO_DIR/bundles/valid"
+INVALID_DIR="$SCENARIO_DIR/bundles/invalid"
+
+echo ""
+echo "=== Scenario 103 — Control Plane Descriptor Bundles ==="
+echo ""
+
+if [ ! -d "$VALIDATOR_DIR" ]; then
+  echo "FAIL: validator directory missing"
+  exit 1
+fi
+
+OUTPUT=$(cd "$VALIDATOR_DIR" && GOWORK=off go run . --valid-dir "$VALID_DIR" --invalid-dir "$INVALID_DIR" 2>&1)
+STATUS=$?
+echo "$OUTPUT"
+
+if [ "$STATUS" -ne 0 ]; then
+  echo "FAIL: control-plane descriptor bundle validator exited $STATUS"
+  exit "$STATUS"
+fi
+
+if echo "$OUTPUT" | grep -q 'SUMMARY: valid=3 invalid=4 public_contract=control-plane.v1alpha1'; then
+  echo "PASS: validator summary proves released control-plane contract execution"
+else
+  echo "FAIL: validator summary missing expected contract/count evidence"
+  exit 1
+fi

--- a/scenarios/103-control-plane-descriptors/validator/main.go
+++ b/scenarios/103-control-plane-descriptors/validator/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/GoCodeAlone/workflow-plugin-control-plane/descriptors"
+	descriptorspb "github.com/GoCodeAlone/workflow-plugin-control-plane/descriptors/pb"
+	"github.com/GoCodeAlone/workflow-plugin-control-plane/envelopes"
+	envelopespb "github.com/GoCodeAlone/workflow-plugin-control-plane/envelopes/pb"
+	"github.com/GoCodeAlone/workflow-plugin-control-plane/registry"
+	registrypb "github.com/GoCodeAlone/workflow-plugin-control-plane/registry/pb"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type bundleFile struct {
+	Kind    string          `json:"kind"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type validationResult struct {
+	Path  string
+	Kind  string
+	Error string
+}
+
+func main() {
+	output, err := runValidation(os.Args[1:])
+	fmt.Print(output)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func runValidation(args []string) (string, error) {
+	fs := flag.NewFlagSet("control-plane-descriptor-validator", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	validDir := fs.String("valid-dir", "", "directory containing valid bundle JSON files")
+	invalidDir := fs.String("invalid-dir", "", "directory containing invalid bundle JSON files")
+	if err := fs.Parse(args); err != nil {
+		return "", err
+	}
+	if *validDir == "" || *invalidDir == "" {
+		return "", fmt.Errorf("--valid-dir and --invalid-dir are required")
+	}
+
+	var out bytes.Buffer
+	validCount, err := validateDir(&out, *validDir, true)
+	if err != nil {
+		return out.String(), err
+	}
+	invalidCount, err := validateDir(&out, *invalidDir, false)
+	if err != nil {
+		return out.String(), err
+	}
+	fmt.Fprintf(&out, "SUMMARY: valid=%d invalid=%d public_contract=%s\n", validCount, invalidCount, descriptors.Version)
+	return out.String(), nil
+}
+
+func validateDir(out io.Writer, dir string, expectValid bool) (int, error) {
+	files, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return 0, err
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		return 0, fmt.Errorf("no bundle fixtures found in %s", dir)
+	}
+	for _, file := range files {
+		result, err := validateBundleFile(file, expectValid)
+		if err != nil {
+			return 0, err
+		}
+		status := "accepted"
+		if !expectValid {
+			status = "rejected"
+		}
+		fmt.Fprintf(out, "PASS: %s %s as %s\n", filepath.Base(file), status, result.Kind)
+	}
+	return len(files), nil
+}
+
+func validateBundleFile(path string, expectValid bool) (validationResult, error) {
+	result := validationResult{Path: path}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return result, err
+	}
+	var bundle bundleFile
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return result, err
+	}
+	result.Kind = bundle.Kind
+	err = validateBundle(bundle)
+	if expectValid {
+		if err != nil {
+			result.Error = err.Error()
+			return result, fmt.Errorf("%s should be valid: %w", path, err)
+		}
+		return result, nil
+	}
+	if err == nil {
+		return result, fmt.Errorf("%s should be invalid but passed", path)
+	}
+	result.Error = err.Error()
+	return result, nil
+}
+
+func validateBundle(bundle bundleFile) error {
+	if bundle.Kind == "" {
+		return fmt.Errorf("kind is required")
+	}
+	if len(bundle.Payload) == 0 {
+		return fmt.Errorf("payload is required")
+	}
+	switch bundle.Kind {
+	case "route_action_descriptor":
+		var msg descriptorspb.RouteActionDescriptor
+		if err := unmarshal(bundle.Payload, &msg); err != nil {
+			return err
+		}
+		return descriptors.ValidateRouteActionDescriptor(&msg)
+	case "audit_envelope":
+		var msg envelopespb.ControlPlaneEnvelope
+		if err := unmarshal(bundle.Payload, &msg); err != nil {
+			return err
+		}
+		return envelopes.ValidateEnvelope(&msg)
+	case "descriptor_registration":
+		var msg registrypb.DescriptorRegistration
+		if err := unmarshal(bundle.Payload, &msg); err != nil {
+			return err
+		}
+		return registry.ValidateDescriptorRegistration(&msg)
+	default:
+		return fmt.Errorf("unsupported bundle kind %q", bundle.Kind)
+	}
+}
+
+func unmarshal(data []byte, msg proto.Message) error {
+	return protojson.UnmarshalOptions{DiscardUnknown: false}.Unmarshal(data, msg)
+}

--- a/scenarios/103-control-plane-descriptors/validator/main_test.go
+++ b/scenarios/103-control-plane-descriptors/validator/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow-plugin-control-plane/descriptors"
+	"github.com/GoCodeAlone/workflow-plugin-control-plane/envelopes"
+	"github.com/GoCodeAlone/workflow-plugin-control-plane/registry"
+)
+
+func TestScenarioControlPlaneBundlesUseReleasedContracts(t *testing.T) {
+	for name, version := range map[string]string{
+		"descriptors": descriptors.Version,
+		"envelopes":   envelopes.Version,
+		"registry":    registry.Version,
+	} {
+		if version != "control-plane.v1alpha1" {
+			t.Fatalf("%s version = %q, want control-plane.v1alpha1", name, version)
+		}
+	}
+}
+
+func TestScenarioControlPlaneBundlesValidateRealArtifacts(t *testing.T) {
+	validFiles, err := filepath.Glob(filepath.Join("..", "bundles", "valid", "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(validFiles) == 0 {
+		t.Fatal("valid bundle fixtures are required")
+	}
+	for _, file := range validFiles {
+		t.Run("valid/"+filepath.Base(file), func(t *testing.T) {
+			result, err := validateBundleFile(file, true)
+			if err != nil {
+				t.Fatalf("valid bundle rejected: %v", err)
+			}
+			if result.Kind == "" || result.Path == "" {
+				t.Fatalf("validation result missing provenance: %+v", result)
+			}
+		})
+	}
+}
+
+func TestScenarioControlPlaneBundlesRejectAuthorityTransferAndStaleArtifacts(t *testing.T) {
+	invalidFiles, err := filepath.Glob(filepath.Join("..", "bundles", "invalid", "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(invalidFiles) < 4 {
+		t.Fatalf("expected at least four invalid fixtures, got %d", len(invalidFiles))
+	}
+	for _, file := range invalidFiles {
+		t.Run("invalid/"+filepath.Base(file), func(t *testing.T) {
+			_, err := validateBundleFile(file, false)
+			if err != nil {
+				t.Fatalf("invalid bundle assertion failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestScenarioControlPlaneBundleRunnerPrintsGeneratedSummary(t *testing.T) {
+	output, err := runValidation([]string{
+		"--valid-dir", filepath.Join("..", "bundles", "valid"),
+		"--invalid-dir", filepath.Join("..", "bundles", "invalid"),
+	})
+	if err != nil {
+		t.Fatalf("runner failed: %v\n%s", err, output)
+	}
+	for _, want := range []string{
+		"valid=3",
+		"invalid=4",
+		"public_contract=control-plane.v1alpha1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("runner output missing %q:\n%s", want, output)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- adds local-only Scenario 103 for control-plane descriptor bundle proof
- validates committed descriptor, envelope, and registration JSON artifacts through released workflow-plugin-control-plane v0.1.0 protobuf validators
- rejects raw URL, secret ref, raw actor identifier, and stale provenance fixtures

## TDD evidence
RED:
```
GOWORK=off go test ./scenarios/103-control-plane-descriptors/... -count=1
# no required module provides package github.com/GoCodeAlone/workflow-plugin-control-plane/descriptors
```

Invariant proof with bad fixture restored:
```
GOWORK=off go test ./scenarios/103-control-plane-descriptors/... -run TestScenarioControlPlaneBundlesValidateRealArtifacts -count=1
FAIL — presentation_ref scheme "presentation" is not a host-scoped control-plane ref
```

GREEN:
```
GOWORK=off go test ./scenarios/103-control-plane-descriptors/... -count=1
ok github.com/GoCodeAlone/workflow-scenarios/scenarios/103-control-plane-descriptors/validator
```

## Verification
```
bash -n scenarios/103-control-plane-descriptors/test/run.sh
GOWORK=off go test ./scenarios/103-control-plane-descriptors/... -count=1
bash scripts/test.sh 103-control-plane-descriptors
git diff --check
! rg -n '/Users/[[:alnum:]_.-]+' scenarios/103-control-plane-descriptors scenarios.json\n```\n\nScenario harness result: `RESULT: ALL TESTS PASSED (8/8)`.\n\n## Locked plan\nPart of workflow-compute T569 from `docs/plans/2026-06-12-control-plane-scenario-proof.md`, PR 1 of 3.