### PR TITLE
Bump workflow to v0.80.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/GoCodeAlone/workflow v0.80.5
+	github.com/GoCodeAlone/workflow v0.80.6
 	github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0
 	github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0 h1:zoWioqUvuNNDfnjHA1s
 github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0/go.mod h1:GDU/jsD6AddmXKedj0wZwieUIaQsTBSGMzuj+XHXMrw=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0 h1:+2M/ecyCxDiXfJM4ibcERuu/BBeIbLTQNcVgRsllR64=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0/go.mod h1:tlVH1mA5yuU8CB7R7+HXIRaBixZoNid6h+5tew5u3FU=
-github.com/GoCodeAlone/workflow v0.80.5 h1:bof1Em6qtUfBxkp/EaHeYxW6jzjRhuuSLU3tGPhHp6g=
-github.com/GoCodeAlone/workflow v0.80.5/go.mod h1:/gFYZ60/KTCMnl2WnR8vGoeSM9p36/BrI4CVr0Ds1+4=
+github.com/GoCodeAlone/workflow v0.80.6 h1:+MFQPOHteI7O6wwfJG6ImVDLOeCW5JlVzg5aQwpJbqo=
+github.com/GoCodeAlone/workflow v0.80.6/go.mod h1:/gFYZ60/KTCMnl2WnR8vGoeSM9p36/BrI4CVr0Ds1+4=
 github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0 h1:XtogtQXVBING2iu5jQGzfubi9rOes/erVWH5uwiPsok=
 github.com/GoCodeAlone/workflow-plugin-control-plane v0.1.0/go.mod h1:2c3Ow7rncEZttzq3XddC+mTD0x5CBE4TdPdvbnH4iYk=
 github.com/GoCodeAlone/workflow-plugin-data-engineering v0.3.1 h1:NPdPpSc3PjYJ5Xzu0YKitMPqrnLB3DW5/pvKFXNHxTM=


### PR DESCRIPTION
## Summary
- bump `github.com/GoCodeAlone/workflow` from `v0.80.5` to `v0.80.6`
- run `GOWORK=off go mod tidy`

## Verification
- `GOWORK=off go test ./...`