### PR TITLE
feat: add Signal encryption scenarios

### DIFF
--- a/scenarios.json
+++ b/scenarios.json
@@ -1235,7 +1235,33 @@
       "localOnly": true,
       "notes": "Validates committed control-plane descriptor, audit envelope, and registration artifacts through released workflow-plugin-control-plane protobuf validators; rejects raw URL, secret ref, raw actor identifier, and stale provenance fixtures without introducing a runtime endpoint.",
       "blockers": []
+    },
+    "104-signal-e2e-encryption": {
+      "status": "testable",
+      "namespace": "local",
+      "deployed": false,
+      "lastTested": null,
+      "lastResult": null,
+      "testCount": 4,
+      "passCount": 0,
+      "failCount": 0,
+      "localOnly": true,
+      "notes": "Runs released workflow-plugin-signal v0.9.0 focused typed-step tests for session prepare -> encrypt -> decrypt and unauthorized principal denial. Proves ciphertext/plaintext separation and authz denial through real plugin code with no official Signal service egress.",
+      "blockers": []
+    },
+    "105-encrypted-spaces-proof-workflow": {
+      "status": "testable",
+      "namespace": "local",
+      "deployed": false,
+      "lastTested": null,
+      "lastResult": null,
+      "testCount": 6,
+      "passCount": 0,
+      "failCount": 0,
+      "localOnly": true,
+      "notes": "Runs released workflow-plugin-encrypted-spaces v0.4.0 focused typed-step tests for vector-backed append verification, tamper rejection, proof-evidence redaction, and required-domain coverage.",
+      "blockers": []
     }
   },
-  "lastUpdated": "2026-06-12T20:32:38.850782Z"
+  "lastUpdated": "2026-07-01T06:58:22Z"
 }

--- a/scenarios/104-signal-e2e-encryption/README.md
+++ b/scenarios/104-signal-e2e-encryption/README.md
@@ -1,0 +1,25 @@
+# Scenario 104 — Signal E2E Encryption
+
+Local-only proof that the released Signal Workflow plugin can perform an
+end-to-end encrypted message exchange using its real typed step code.
+
+The scenario creates a temporary Go module, pins
+`github.com/GoCodeAlone/workflow-plugin-signal@v0.9.0`, then runs the released
+plugin's focused step tests:
+
+- `TestSignalSessionPrepareEncryptDecryptRoundTrip`
+- `TestSignalDecryptDeniesUnauthorizedPrincipalWithoutPlaintext`
+
+Those tests execute the actual Workflow plugin step implementations for
+identity setup, pre-key bundle preparation, encryption, decrypt authorization,
+and decryption. The test asserts ciphertext does not contain plaintext and that
+an unauthorized principal cannot recover plaintext.
+
+## Running
+
+```bash
+bash scenarios/104-signal-e2e-encryption/test/run.sh
+```
+
+No official Signal service endpoint, account, phone number, or production
+transport is used.

--- a/scenarios/104-signal-e2e-encryption/scenario.yaml
+++ b/scenarios/104-signal-e2e-encryption/scenario.yaml
@@ -1,0 +1,26 @@
+name: Signal E2E Encryption
+id: "104-signal-e2e-encryption"
+category: C
+description: |
+  Local-only proof that the released Signal Workflow plugin performs a real
+  end-to-end encrypted message exchange through its typed step code.
+
+  The scenario creates a temporary Go module, pins
+  workflow-plugin-signal v0.9.0, and runs the released plugin's focused internal
+  step tests for session prepare -> encrypt -> decrypt plus unauthorized
+  principal denial. This executes the plugin's real typed step implementations
+  and libsignal-go session code; it does not reimplement the cryptography and
+  does not contact the official Signal service.
+components:
+  - workflow-plugin-signal v0.9.0
+  - libsignal-go session/pre-key primitives
+  - step.signal_session_prepare
+  - step.signal_encrypt
+  - step.signal_decrypt
+status: testable
+tags:
+  - signal
+  - e2e-encryption
+  - workflow-plugin
+  - local-only
+runtime: local

--- a/scenarios/104-signal-e2e-encryption/test/run.sh
+++ b/scenarios/104-signal-e2e-encryption/test/run.sh
@@ -19,7 +19,12 @@ echo ""
 echo "=== Scenario 104 — Signal E2E Encryption ==="
 echo ""
 
-WORKDIR="$(mktemp -d)"
+if ! WORKDIR="$(mktemp -d)"; then
+  fail "could not create temporary module workspace"
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed"
+  exit 1
+fi
 trap 'rm -rf "$WORKDIR"' EXIT
 
 (

--- a/scenarios/104-signal-e2e-encryption/test/run.sh
+++ b/scenarios/104-signal-e2e-encryption/test/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Scenario 104 — Signal E2E Encryption.
+#
+# Demonstration-fidelity: this script runs the real released
+# workflow-plugin-signal v0.9.0 typed step tests. PASS/FAIL lines are derived
+# from `go test` output, not from hard-coded expected output.
+set -uo pipefail
+
+PLUGIN_VERSION="${PLUGIN_VERSION:-v0.9.0}"
+PKG="github.com/GoCodeAlone/workflow-plugin-signal/internal"
+TEST_RE='TestSignalSessionPrepareEncryptDecryptRoundTrip|TestSignalDecryptDeniesUnauthorizedPrincipalWithoutPlaintext'
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== Scenario 104 — Signal E2E Encryption ==="
+echo ""
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+(
+  cd "$WORKDIR" || exit 1
+  go mod init scenario-104-signal-e2e >/dev/null
+  go get "${PKG}@${PLUGIN_VERSION}" >/dev/null
+)
+if [ "$?" -eq 0 ]; then
+  pass "pinned workflow-plugin-signal ${PLUGIN_VERSION}"
+else
+  fail "could not pin workflow-plugin-signal ${PLUGIN_VERSION}"
+fi
+
+OUTPUT="$(
+  cd "$WORKDIR" && go test "$PKG" -run "$TEST_RE" -count=1 -v 2>&1
+)"
+STATUS=$?
+echo "$OUTPUT"
+
+if [ "$STATUS" -eq 0 ]; then
+  pass "released Signal plugin E2E encryption tests passed"
+else
+  fail "released Signal plugin E2E encryption tests failed"
+fi
+
+echo "$OUTPUT" | grep -q 'TestSignalSessionPrepareEncryptDecryptRoundTrip' \
+  && pass "session prepare -> encrypt -> decrypt round trip executed" \
+  || fail "round-trip test did not execute"
+
+echo "$OUTPUT" | grep -q 'TestSignalDecryptDeniesUnauthorizedPrincipalWithoutPlaintext' \
+  && pass "unauthorized principal denial executed" \
+  || fail "unauthorized principal denial test did not execute"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scenarios/105-encrypted-spaces-proof-workflow/README.md
+++ b/scenarios/105-encrypted-spaces-proof-workflow/README.md
@@ -22,4 +22,4 @@ proof-evidence redaction.
 bash scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
 ```
 
-No live Signal service egress is used.
+No live external service egress is used.

--- a/scenarios/105-encrypted-spaces-proof-workflow/README.md
+++ b/scenarios/105-encrypted-spaces-proof-workflow/README.md
@@ -1,0 +1,25 @@
+# Scenario 105 — Encrypted Spaces Proof Workflow
+
+Local-only proof that the released Encrypted Spaces Workflow plugin can verify a
+proof-gated append flow and emit redacted proof evidence.
+
+The scenario creates a temporary Go module, pins
+`github.com/GoCodeAlone/workflow-plugin-encrypted-spaces@v0.4.0`, then runs the
+released plugin's focused proof workflow tests:
+
+- `TestAppendVerifiedAcceptsVectorBackedProof`
+- `TestAppendVerifiedRejectsTamperedProof`
+- `TestProofEvidenceRedactsPlaintextAndKeyMaterial`
+- `TestVectorReportStepFiltersRequiredDomains`
+
+Those tests execute the actual Workflow plugin step implementations for
+vector-backed append verification, tamper rejection, coverage filtering, and
+proof-evidence redaction.
+
+## Running
+
+```bash
+bash scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+```
+
+No live Signal service egress is used.

--- a/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
+++ b/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
@@ -1,0 +1,25 @@
+name: Encrypted Spaces Proof Workflow
+id: "105-encrypted-spaces-proof-workflow"
+category: C
+description: |
+  Local-only proof that the released Encrypted Spaces Workflow plugin verifies
+  a proof-gated append flow and emits redacted proof evidence.
+
+  The scenario creates a temporary Go module, pins
+  workflow-plugin-encrypted-spaces v0.4.0, and runs the released plugin's
+  focused tests for vector-backed append verification, tamper rejection,
+  proof-evidence redaction, and required-domain vector coverage. This executes
+  the real plugin step implementations backed by encrypted-spaces-go.
+components:
+  - workflow-plugin-encrypted-spaces v0.4.0
+  - encrypted-spaces-go proof policy
+  - step.encrypted_space_append_verified
+  - step.encrypted_space_proof_evidence
+  - step.encrypted_space_vector_report
+status: testable
+tags:
+  - encrypted-spaces
+  - proof-workflow
+  - workflow-plugin
+  - local-only
+runtime: local

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Scenario 105 — Encrypted Spaces Proof Workflow.
+#
+# Demonstration-fidelity: this script runs the real released
+# workflow-plugin-encrypted-spaces v0.4.0 typed step tests. PASS/FAIL lines are
+# derived from `go test` output, not from hard-coded expected output.
+set -uo pipefail
+
+PLUGIN_VERSION="${PLUGIN_VERSION:-v0.4.0}"
+PKG="github.com/GoCodeAlone/workflow-plugin-encrypted-spaces/internal"
+TEST_RE='TestAppendVerifiedAcceptsVectorBackedProof|TestAppendVerifiedRejectsTamperedProof|TestProofEvidenceRedactsPlaintextAndKeyMaterial|TestVectorReportStepFiltersRequiredDomains'
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== Scenario 105 — Encrypted Spaces Proof Workflow ==="
+echo ""
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+(
+  cd "$WORKDIR" || exit 1
+  go mod init scenario-105-encrypted-spaces >/dev/null
+  go get "${PKG}@${PLUGIN_VERSION}" >/dev/null
+)
+if [ "$?" -eq 0 ]; then
+  pass "pinned workflow-plugin-encrypted-spaces ${PLUGIN_VERSION}"
+else
+  fail "could not pin workflow-plugin-encrypted-spaces ${PLUGIN_VERSION}"
+fi
+
+OUTPUT="$(
+  cd "$WORKDIR" && go test "$PKG" -run "$TEST_RE" -count=1 -v 2>&1
+)"
+STATUS=$?
+echo "$OUTPUT"
+
+if [ "$STATUS" -eq 0 ]; then
+  pass "released Encrypted Spaces proof workflow tests passed"
+else
+  fail "released Encrypted Spaces proof workflow tests failed"
+fi
+
+echo "$OUTPUT" | grep -q 'TestAppendVerifiedAcceptsVectorBackedProof' \
+  && pass "vector-backed append verification executed" \
+  || fail "vector-backed append verification test did not execute"
+
+echo "$OUTPUT" | grep -q 'TestAppendVerifiedRejectsTamperedProof' \
+  && pass "tamper rejection executed" \
+  || fail "tamper rejection test did not execute"
+
+echo "$OUTPUT" | grep -q 'TestProofEvidenceRedactsPlaintextAndKeyMaterial' \
+  && pass "proof evidence redaction executed" \
+  || fail "proof evidence redaction test did not execute"
+
+echo "$OUTPUT" | grep -q 'TestVectorReportStepFiltersRequiredDomains' \
+  && pass "required-domain vector coverage executed" \
+  || fail "required-domain vector coverage test did not execute"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -19,7 +19,12 @@ echo ""
 echo "=== Scenario 105 — Encrypted Spaces Proof Workflow ==="
 echo ""
 
-WORKDIR="$(mktemp -d)"
+if ! WORKDIR="$(mktemp -d)"; then
+  fail "could not create temporary module workspace"
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed"
+  exit 1
+fi
 trap 'rm -rf "$WORKDIR"' EXIT
 
 (


### PR DESCRIPTION
## Summary
- add scenario 104 proving Signal Workflow e2e encryption through released workflow-plugin-signal v0.9.0 typed-step tests
- add scenario 105 proving Encrypted Spaces verified append, tamper rejection, redacted proof evidence, and vector-domain coverage through released workflow-plugin-encrypted-spaces v0.4.0 tests
- register both as local-only testable scenarios with no official Signal service egress

## Verification
- bash scenarios/104-signal-e2e-encryption/test/run.sh
- bash scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
- WORKFLOW_DIR=/Users/jon/workspace/workflow ./scripts/pre-push
- python3 YAML load for all scenario.yaml files
- make list | rg '104-signal-e2e-encryption|105-encrypted-spaces-proof-workflow'
- git diff --check