### PR TITLE
[codex] Exercise Signal scenarios through Workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,13 @@ PVCs persist across upgrades/teardowns for data durability.
 5. Write tests in `scenarios/<id>-<name>/test/run.sh` using `PASS:` / `FAIL:` prefixes
 6. Add entry to `scenarios.json`
 
-Scenario tests must exercise a Workflow application path. Prefer `wfctl
-pipeline run`, `wfctl test`, a deployed `workflow-server`, or another path that
-builds a Workflow engine from scenario configuration and executes modules,
-triggers, or pipeline steps. Package tests, library unit tests, schema
+Scenario tests must exercise a Workflow application path. Prefer a deployed
+`workflow-server` or another path that builds a Workflow engine from scenario
+configuration and drives the app through its real API, trigger, CLI, or event
+boundary. `wfctl pipeline run` and `wfctl test` are acceptable when the
+scenario itself is a pipeline/tooling contract; they are not sufficient for
+scenarios that claim multi-client communication, collaboration, auth, storage,
+or other application behavior. Package tests, library unit tests, schema
 validation, and generated fixture checks are supporting evidence only; they are
 not sufficient by themselves for a `workflow-scenarios` entry.
 
@@ -55,3 +58,8 @@ plugin mechanism and execute it from `config/app.yaml`. For external services
 or storage providers, use committed mocks, fakes, local emulators, or an
 explicitly approved live environment, and document that boundary in the
 scenario README and test script.
+
+Application scenario workflows should be actor/resource-parametric. A config may
+declare a pool of known local identities, tenants, stores, or fixtures, but
+pipelines should take participant/resource IDs from route params, request
+bodies, events, or CLI inputs instead of hard-coding a single demo interaction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,16 @@ PVCs persist across upgrades/teardowns for data durability.
 4. Add seed data in `scenarios/<id>-<name>/seed/seed.sh`
 5. Write tests in `scenarios/<id>-<name>/test/run.sh` using `PASS:` / `FAIL:` prefixes
 6. Add entry to `scenarios.json`
+
+Scenario tests must exercise a Workflow application path. Prefer `wfctl
+pipeline run`, `wfctl test`, a deployed `workflow-server`, or another path that
+builds a Workflow engine from scenario configuration and executes modules,
+triggers, or pipeline steps. Package tests, library unit tests, schema
+validation, and generated fixture checks are supporting evidence only; they are
+not sufficient by themselves for a `workflow-scenarios` entry.
+
+When a scenario covers a Workflow plugin, load the plugin through Workflow's
+plugin mechanism and execute it from `config/app.yaml`. For external services
+or storage providers, use committed mocks, fakes, local emulators, or an
+explicitly approved live environment, and document that boundary in the
+scenario README and test script.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ Persistent regression and resiliency scenarios for the Workflow ecosystem.
 
 ## Scenario Proof Standard
 
-A scenario must exercise a Workflow application path. Prefer `wfctl pipeline
-run`, `wfctl test`, a deployed `workflow-server`, or another path that builds a
-Workflow engine from scenario configuration and runs one or more modules,
-triggers, or pipeline steps.
+A scenario must exercise a Workflow application path. Prefer a deployed
+`workflow-server` or another path that builds a Workflow engine from scenario
+configuration and then drives it through the same API, trigger, CLI, or event
+boundary an application user would use. `wfctl pipeline run` and `wfctl test`
+are acceptable when the scenario itself is a pipeline/tooling contract; they are
+not sufficient for scenarios that claim multi-client communication,
+collaboration, auth, storage, or other application behavior.
 
 Package tests, library unit tests, schema validation, and generated fixture
 checks are useful supporting evidence, but they are not sufficient by
@@ -20,6 +23,14 @@ use committed mocks, fakes, local emulators, or explicitly approved live
 environments. A scenario that claims to cover S3, Signal, SaaS APIs, or similar
 dependencies must make the dependency boundary clear in its README and test
 script.
+
+Application scenarios should be actor/resource-parametric. It is acceptable for
+the app config to define a pool of known local identities, tenants, stores, or
+fixtures required by the engine, but workflows should not bake a single demo
+conversation such as "Alice sends exactly this message to Bob" into their step
+graph. The test runner should choose participant/resource IDs and submit
+requests as clients. Hard-coded values belong only to explicit fixtures, vector
+data, mock endpoints, and other documented test inputs.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Workflow Scenarios
+
+Persistent regression and resiliency scenarios for the Workflow ecosystem.
+
+## Scenario Proof Standard
+
+A scenario must exercise a Workflow application path. Prefer `wfctl pipeline
+run`, `wfctl test`, a deployed `workflow-server`, or another path that builds a
+Workflow engine from scenario configuration and runs one or more modules,
+triggers, or pipeline steps.
+
+Package tests, library unit tests, schema validation, and generated fixture
+checks are useful supporting evidence, but they are not sufficient by
+themselves for a `workflow-scenarios` entry. If a scenario covers a Workflow
+plugin, it should load the plugin through Workflow's plugin mechanism and
+execute the plugin from a Workflow app config.
+
+Scenarios that would normally require external services or object stores should
+use committed mocks, fakes, local emulators, or explicitly approved live
+environments. A scenario that claims to cover S3, Signal, SaaS APIs, or similar
+dependencies must make the dependency boundary clear in its README and test
+script.
+
+## Running
+
+```bash
+make list
+make test SCENARIO=104-signal-e2e-encryption
+make test SCENARIO=105-encrypted-spaces-proof-workflow
+```

--- a/scenarios.json
+++ b/scenarios.json
@@ -1060,7 +1060,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "testCount": 6,
+      "testCount": 7,
       "passCount": 6,
       "failCount": 0,
       "localOnly": true,
@@ -1237,31 +1237,31 @@
       "blockers": []
     },
     "104-signal-e2e-encryption": {
-      "status": "testable",
+      "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": null,
-      "lastResult": null,
-      "testCount": 4,
-      "passCount": 0,
+      "lastTested": "2026-07-01T13:23:26.393784Z",
+      "lastResult": "pass",
+      "testCount": 7,
+      "passCount": 7,
       "failCount": 0,
       "localOnly": true,
-      "notes": "Runs released workflow-plugin-signal v0.9.0 focused typed-step tests for session prepare -> encrypt -> decrypt and unauthorized principal denial. Proves ciphertext/plaintext separation and authz denial through real plugin code with no official Signal service egress.",
+      "notes": "Builds workflow-plugin-signal as an external plugin, loads it through wfctl pipeline run, and executes a Workflow app pipeline for session prepare -> encrypt -> decrypt. Proves decrypted plaintext reaches Workflow output with no official Signal service egress.",
       "blockers": []
     },
     "105-encrypted-spaces-proof-workflow": {
-      "status": "testable",
+      "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": null,
-      "lastResult": null,
-      "testCount": 6,
-      "passCount": 0,
+      "lastTested": "2026-07-01T13:23:34.249401Z",
+      "lastResult": "pass",
+      "testCount": 8,
+      "passCount": 8,
       "failCount": 0,
       "localOnly": true,
-      "notes": "Runs released workflow-plugin-encrypted-spaces v0.4.0 focused typed-step tests for vector-backed append verification, tamper rejection, proof-evidence redaction, and required-domain coverage.",
+      "notes": "Builds workflow-plugin-encrypted-spaces as an external plugin, loads it through wfctl pipeline run, and executes a Workflow app pipeline for in-memory encrypted-space append, verified commitment, and proof evidence. No S3 or live external service egress.",
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T06:58:22Z"
+  "lastUpdated": "2026-07-01T13:23:34.249401Z"
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -6,7 +6,7 @@
       "deployed": true,
       "lastTested": "2026-03-28T22:17:10.518840Z",
       "lastResult": "pass",
-      "testCount": 6,
+      "testCount": 7,
       "passCount": 7,
       "failCount": 0,
       "blockers": []
@@ -1060,7 +1060,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "testCount": 7,
+      "testCount": 6,
       "passCount": 6,
       "failCount": 0,
       "localOnly": true,

--- a/scenarios.json
+++ b/scenarios.json
@@ -6,7 +6,7 @@
       "deployed": true,
       "lastTested": "2026-03-28T22:17:10.518840Z",
       "lastResult": "pass",
-      "testCount": 7,
+      "testCount": 6,
       "passCount": 7,
       "failCount": 0,
       "blockers": []
@@ -1253,7 +1253,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T14:21:51.610316Z",
+      "lastTested": "2026-07-01T14:39:47.986046Z",
       "lastResult": "pass",
       "testCount": 12,
       "passCount": 12,
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T14:21:51.610316Z"
+  "lastUpdated": "2026-07-01T14:39:47.986046Z"
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1240,7 +1240,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T13:33:01.533651Z",
+      "lastTested": "2026-07-01T13:57:29.803200Z",
       "lastResult": "pass",
       "testCount": 7,
       "passCount": 7,
@@ -1253,7 +1253,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T13:33:01.134244Z",
+      "lastTested": "2026-07-01T13:57:32.970765Z",
       "lastResult": "pass",
       "testCount": 8,
       "passCount": 8,
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T13:33:01.533651Z"
+  "lastUpdated": "2026-07-01T13:57:32.970765Z"
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1240,28 +1240,28 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T13:57:29.803200Z",
+      "lastTested": "2026-07-01T14:21:40.882137Z",
       "lastResult": "pass",
-      "testCount": 7,
-      "passCount": 7,
+      "testCount": 12,
+      "passCount": 12,
       "failCount": 0,
       "localOnly": true,
-      "notes": "Builds workflow-plugin-signal as an external plugin, loads it through wfctl pipeline run, and executes a Workflow app pipeline for session prepare -> encrypt -> decrypt. Proves decrypted plaintext reaches Workflow output with no official Signal service egress.",
+      "notes": "Builds workflow-plugin-signal as an external plugin, launches workflow-server, and drives participant-parametric HTTP APIs for session prepare -> encrypt -> decrypt. Proves two clients exchange an encrypted message through the running Workflow app with no official Signal service egress.",
       "blockers": []
     },
     "105-encrypted-spaces-proof-workflow": {
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T13:57:32.970765Z",
+      "lastTested": "2026-07-01T14:21:51.610316Z",
       "lastResult": "pass",
-      "testCount": 8,
-      "passCount": 8,
+      "testCount": 12,
+      "passCount": 12,
       "failCount": 0,
       "localOnly": true,
-      "notes": "Builds workflow-plugin-encrypted-spaces as an external plugin, loads it through wfctl pipeline run, and executes a Workflow app pipeline for in-memory encrypted-space append, verified commitment, and proof evidence. No S3 or live external service egress.",
+      "notes": "Builds workflow-plugin-encrypted-spaces as an external plugin, launches workflow-server, and drives space-parametric HTTP APIs for operation append, verified commitment, and proof evidence. Uses an in-memory store fixture with no S3 or live external service egress.",
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T13:57:32.970765Z"
+  "lastUpdated": "2026-07-01T14:21:51.610316Z"
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1240,7 +1240,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T13:23:26.393784Z",
+      "lastTested": "2026-07-01T13:33:01.533651Z",
       "lastResult": "pass",
       "testCount": 7,
       "passCount": 7,
@@ -1253,7 +1253,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T13:23:34.249401Z",
+      "lastTested": "2026-07-01T13:33:01.134244Z",
       "lastResult": "pass",
       "testCount": 8,
       "passCount": 8,
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T13:23:34.249401Z"
+  "lastUpdated": "2026-07-01T13:33:01.533651Z"
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1240,7 +1240,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T14:21:40.882137Z",
+      "lastTested": "2026-07-01T14:54:36.684390Z",
       "lastResult": "pass",
       "testCount": 12,
       "passCount": 12,
@@ -1253,7 +1253,7 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T14:49:25.315689Z",
+      "lastTested": "2026-07-01T14:54:36.688040Z",
       "lastResult": "pass",
       "testCount": 12,
       "passCount": 12,
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T14:49:25.315689Z"
+  "lastUpdated": "2026-07-01T14:54:36.688040Z"
 }

--- a/scenarios.json
+++ b/scenarios.json
@@ -1253,15 +1253,15 @@
       "status": "passed",
       "namespace": "local",
       "deployed": false,
-      "lastTested": "2026-07-01T14:39:47.986046Z",
+      "lastTested": "2026-07-01T14:49:25.315689Z",
       "lastResult": "pass",
       "testCount": 12,
       "passCount": 12,
       "failCount": 0,
       "localOnly": true,
-      "notes": "Builds workflow-plugin-encrypted-spaces as an external plugin, launches workflow-server, and drives space-parametric HTTP APIs for operation append, verified commitment, and proof evidence. Uses an in-memory store fixture with no S3 or live external service egress.",
+      "notes": "Builds workflow-plugin-encrypted-spaces as an external plugin, launches workflow-server, and drives fixture-backed HTTP APIs for operation append, verified commitment, and proof evidence. Uses an in-memory store fixture with a space-1/member-1 proof vector and no S3 or live external service egress.",
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T14:39:47.986046Z"
+  "lastUpdated": "2026-07-01T14:49:25.315689Z"
 }

--- a/scenarios/104-signal-e2e-encryption/README.md
+++ b/scenarios/104-signal-e2e-encryption/README.md
@@ -1,12 +1,19 @@
 # Scenario 104 - Signal E2E Encryption
 
 Local-only Workflow app proof that the Signal Workflow plugin can perform an
-end-to-end encrypted message exchange through `wfctl pipeline run`.
+end-to-end encrypted message exchange through a running Workflow API.
 
 The scenario builds `workflow-plugin-signal`, loads it as an external Workflow
-plugin, and runs `config/app.yaml` with the Workflow engine. The app prepares a
-Bob pre-key bundle, encrypts a base64 message as Alice, decrypts as Bob, and
-asserts that the decrypted plaintext appears in Workflow pipeline output.
+plugin under a temporary `data/plugins` directory, launches the real Workflow
+server, and drives participant-parametric HTTP routes:
+
+- client B publishes a pre-key bundle via `POST /participants/{id}/session`
+- client A encrypts a message via `POST /participants/{id}/messages`
+- client B decrypts the envelope via `POST /participants/{id}/messages/decrypt`
+
+The app config contains a small local identity pool, but the workflows take
+participant IDs and message content from HTTP route params and request bodies.
+They do not hard-code an Alice/Bob conversation.
 
 ## Running
 
@@ -14,8 +21,8 @@ asserts that the decrypted plaintext appears in Workflow pipeline output.
 bash scenarios/104-signal-e2e-encryption/test/run.sh
 ```
 
-Set `WFCTL`, `WORKFLOW_REPO`, or `SIGNAL_PLUGIN_REPO` when running outside the
-standard workspace layout.
+Set `WORKFLOW_SERVER`, `WORKFLOW_REPO`, or `SIGNAL_PLUGIN_REPO` when running
+outside the standard workspace layout.
 
 No official Signal service endpoint, account, phone number, or production
 transport is used.

--- a/scenarios/104-signal-e2e-encryption/README.md
+++ b/scenarios/104-signal-e2e-encryption/README.md
@@ -1,25 +1,21 @@
-# Scenario 104 — Signal E2E Encryption
+# Scenario 104 - Signal E2E Encryption
 
-Local-only proof that the released Signal Workflow plugin can perform an
-end-to-end encrypted message exchange using its real typed step code.
+Local-only Workflow app proof that the Signal Workflow plugin can perform an
+end-to-end encrypted message exchange through `wfctl pipeline run`.
 
-The scenario creates a temporary Go module, pins
-`github.com/GoCodeAlone/workflow-plugin-signal@v0.9.0`, then runs the released
-plugin's focused step tests:
-
-- `TestSignalSessionPrepareEncryptDecryptRoundTrip`
-- `TestSignalDecryptDeniesUnauthorizedPrincipalWithoutPlaintext`
-
-Those tests execute the actual Workflow plugin step implementations for
-identity setup, pre-key bundle preparation, encryption, decrypt authorization,
-and decryption. The test asserts ciphertext does not contain plaintext and that
-an unauthorized principal cannot recover plaintext.
+The scenario builds `workflow-plugin-signal`, loads it as an external Workflow
+plugin, and runs `config/app.yaml` with the Workflow engine. The app prepares a
+Bob pre-key bundle, encrypts a base64 message as Alice, decrypts as Bob, and
+asserts that the decrypted plaintext appears in Workflow pipeline output.
 
 ## Running
 
 ```bash
 bash scenarios/104-signal-e2e-encryption/test/run.sh
 ```
+
+Set `WFCTL`, `WORKFLOW_REPO`, or `SIGNAL_PLUGIN_REPO` when running outside the
+standard workspace layout.
 
 No official Signal service endpoint, account, phone number, or production
 transport is used.

--- a/scenarios/104-signal-e2e-encryption/config/app.yaml
+++ b/scenarios/104-signal-e2e-encryption/config/app.yaml
@@ -1,66 +1,119 @@
 modules:
-  - name: alice_identity
+  - name: server
+    type: http.server
+    config:
+      address: ":18104"
+
+  - name: router
+    type: http.router
+    dependsOn: [server]
+
+  - name: participant_a_identity
     type: signal.identity_store
     config:
-      identity_ref: alice
-      local_id: alice@example.test
+      identity_ref: user-a
+      local_id: user-a@example.test
       device_id: 1
       registration_id: 1001
-  - name: bob_identity
+
+  - name: participant_b_identity
     type: signal.identity_store
     config:
-      identity_ref: bob
-      local_id: bob@example.test
+      identity_ref: user-b
+      local_id: user-b@example.test
       device_id: 1
       registration_id: 2002
 
+workflows:
+  http:
+    server: server
+    router: router
+
 pipelines:
-  signal-e2e:
+  healthz:
+    trigger: { type: http, config: { path: /healthz, method: GET } }
     steps:
-      - name: prepare_bob
+      - name: ok
+        type: step.json_response
+        config:
+          status: 200
+          body: { status: ok, scenario: "104-signal-e2e-encryption" }
+
+  prepare-session:
+    trigger:
+      type: http
+      config:
+        path: /participants/{participant}/session
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [participant]
+      - name: prepare
         type: step.signal_session_prepare
         config:
-          identity_ref: bob
-      - name: encrypt_input
-        type: step.set
+          identity_ref: '{{ index .steps "parse" "path_params" "participant" }}'
+      - name: respond
+        type: step.json_response
         config:
-          values:
-            remote_id: bob@example.test
-            remote_device_id: 1
-            plaintext: cHJpdmF0ZSB3b3JrZmxvdyBtZXNzYWdl
-            remote_bundle:
-              identity_ref: "{{ index .steps \"prepare_bob\" \"bundle\" \"identity_ref\" }}"
-              local_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"local_id\" }}"
-              device_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"device_id\" }}"
-              registration_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"registration_id\" }}"
-              pre_key_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"pre_key_id\" }}"
-              pre_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"pre_key\" }}"
-              signed_pre_key_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"signed_pre_key_id\" }}"
-              signed_pre_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"signed_pre_key\" }}"
-              signed_pre_key_signature: "{{ index .steps \"prepare_bob\" \"bundle\" \"signed_pre_key_signature\" }}"
-              kyber_pre_key_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"kyber_pre_key_id\" }}"
-              kyber_pre_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"kyber_pre_key\" }}"
-              kyber_pre_key_signature: "{{ index .steps \"prepare_bob\" \"bundle\" \"kyber_pre_key_signature\" }}"
-              identity_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"identity_key\" }}"
+          status: 200
+          body:
+            participant: '{{ index .steps "parse" "path_params" "participant" }}'
+            bundle:
+              _from: steps.prepare.bundle
+    on_error: stop
+
+  encrypt-message:
+    trigger:
+      type: http
+      config:
+        path: /participants/{sender}/messages
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [sender]
+          parse_body: true
+          merge_body: true
       - name: encrypt
         type: step.signal_encrypt
         config:
-          identity_ref: alice
-      - name: decrypt_input
-        type: step.set
+          identity_ref: '{{ index .steps "parse" "path_params" "sender" }}'
+      - name: respond
+        type: step.json_response
         config:
-          values:
-            principal: bob-user
+          status: 200
+          body:
+            sender: '{{ index .steps "parse" "path_params" "sender" }}'
             envelope:
-              sender_id: "{{ index .steps \"encrypt\" \"envelope\" \"sender_id\" }}"
-              sender_device_id: "{{ index .steps \"encrypt\" \"envelope\" \"sender_device_id\" }}"
-              recipient_id: "{{ index .steps \"encrypt\" \"envelope\" \"recipient_id\" }}"
-              recipient_device_id: "{{ index .steps \"encrypt\" \"envelope\" \"recipient_device_id\" }}"
-              message_type: "{{ index .steps \"encrypt\" \"envelope\" \"message_type\" }}"
-              ciphertext: "{{ index .steps \"encrypt\" \"envelope\" \"ciphertext\" }}"
+              _from: steps.encrypt.envelope
+    on_error: stop
+
+  decrypt-message:
+    trigger:
+      type: http
+      config:
+        path: /participants/{recipient}/messages/decrypt
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [recipient]
+          parse_body: true
+          merge_body: true
       - name: decrypt
         type: step.signal_decrypt
         config:
-          identity_ref: bob
-          required_principal: bob-user
+          identity_ref: '{{ index .steps "parse" "path_params" "recipient" }}'
+          required_principal: "{{ .principal }}"
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            recipient: '{{ index .steps "parse" "path_params" "recipient" }}'
+            plaintext: "{{ .steps.decrypt.plaintext }}"
     on_error: stop

--- a/scenarios/104-signal-e2e-encryption/config/app.yaml
+++ b/scenarios/104-signal-e2e-encryption/config/app.yaml
@@ -1,0 +1,66 @@
+modules:
+  - name: alice_identity
+    type: signal.identity_store
+    config:
+      identity_ref: alice
+      local_id: alice@example.test
+      device_id: 1
+      registration_id: 1001
+  - name: bob_identity
+    type: signal.identity_store
+    config:
+      identity_ref: bob
+      local_id: bob@example.test
+      device_id: 1
+      registration_id: 2002
+
+pipelines:
+  signal-e2e:
+    steps:
+      - name: prepare_bob
+        type: step.signal_session_prepare
+        config:
+          identity_ref: bob
+      - name: encrypt_input
+        type: step.set
+        config:
+          values:
+            remote_id: bob@example.test
+            remote_device_id: 1
+            plaintext: cHJpdmF0ZSB3b3JrZmxvdyBtZXNzYWdl
+            remote_bundle:
+              identity_ref: "{{ index .steps \"prepare_bob\" \"bundle\" \"identity_ref\" }}"
+              local_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"local_id\" }}"
+              device_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"device_id\" }}"
+              registration_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"registration_id\" }}"
+              pre_key_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"pre_key_id\" }}"
+              pre_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"pre_key\" }}"
+              signed_pre_key_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"signed_pre_key_id\" }}"
+              signed_pre_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"signed_pre_key\" }}"
+              signed_pre_key_signature: "{{ index .steps \"prepare_bob\" \"bundle\" \"signed_pre_key_signature\" }}"
+              kyber_pre_key_id: "{{ index .steps \"prepare_bob\" \"bundle\" \"kyber_pre_key_id\" }}"
+              kyber_pre_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"kyber_pre_key\" }}"
+              kyber_pre_key_signature: "{{ index .steps \"prepare_bob\" \"bundle\" \"kyber_pre_key_signature\" }}"
+              identity_key: "{{ index .steps \"prepare_bob\" \"bundle\" \"identity_key\" }}"
+      - name: encrypt
+        type: step.signal_encrypt
+        config:
+          identity_ref: alice
+      - name: decrypt_input
+        type: step.set
+        config:
+          values:
+            principal: bob-user
+            envelope:
+              sender_id: "{{ index .steps \"encrypt\" \"envelope\" \"sender_id\" }}"
+              sender_device_id: "{{ index .steps \"encrypt\" \"envelope\" \"sender_device_id\" }}"
+              recipient_id: "{{ index .steps \"encrypt\" \"envelope\" \"recipient_id\" }}"
+              recipient_device_id: "{{ index .steps \"encrypt\" \"envelope\" \"recipient_device_id\" }}"
+              message_type: "{{ index .steps \"encrypt\" \"envelope\" \"message_type\" }}"
+              ciphertext: "{{ index .steps \"encrypt\" \"envelope\" \"ciphertext\" }}"
+      - name: decrypt
+        type: step.signal_decrypt
+        config:
+          identity_ref: bob
+          required_principal: bob-user
+    on_error: stop

--- a/scenarios/104-signal-e2e-encryption/scenario.yaml
+++ b/scenarios/104-signal-e2e-encryption/scenario.yaml
@@ -2,17 +2,18 @@ name: Signal E2E Encryption
 id: "104-signal-e2e-encryption"
 category: C
 description: |
-  Local-only proof that the released Signal Workflow plugin performs a real
-  end-to-end encrypted message exchange through its typed step code.
+  Local-only Workflow app proof that the Signal Workflow plugin performs a real
+  end-to-end encrypted message exchange through wfctl pipeline run.
 
-  The scenario creates a temporary Go module, pins
-  workflow-plugin-signal v0.9.0, and runs the released plugin's focused internal
-  step tests for session prepare -> encrypt -> decrypt plus unauthorized
-  principal denial. This executes the plugin's real typed step implementations
-  and libsignal-go session code; it does not reimplement the cryptography and
-  does not contact the official Signal service.
+  The scenario builds workflow-plugin-signal as an external plugin, loads it
+  through wfctl, and runs config/app.yaml with the Workflow engine. The pipeline
+  prepares a Bob bundle, encrypts as Alice, decrypts as Bob, and asserts the
+  decrypted plaintext from Workflow output. It does not contact the official
+  Signal service.
 components:
-  - workflow-plugin-signal v0.9.0
+  - workflow-plugin-signal
+  - wfctl pipeline run
+  - Workflow external plugin loader
   - libsignal-go session/pre-key primitives
   - step.signal_session_prepare
   - step.signal_encrypt

--- a/scenarios/104-signal-e2e-encryption/scenario.yaml
+++ b/scenarios/104-signal-e2e-encryption/scenario.yaml
@@ -3,16 +3,18 @@ id: "104-signal-e2e-encryption"
 category: C
 description: |
   Local-only Workflow app proof that the Signal Workflow plugin performs a real
-  end-to-end encrypted message exchange through wfctl pipeline run.
+  end-to-end encrypted message exchange through a running Workflow API.
 
   The scenario builds workflow-plugin-signal as an external plugin, loads it
-  through wfctl, and runs config/app.yaml with the Workflow engine. The pipeline
-  prepares a Bob bundle, encrypts as Alice, decrypts as Bob, and asserts the
-  decrypted plaintext from Workflow output. It does not contact the official
-  Signal service.
+  through the Workflow server's data/plugins path, and starts config/app.yaml
+  with HTTP routes for participant session prep, message encryption, and message
+  decryption. The test chooses two participants from the app's local identity
+  pool and exchanges a message through separate API calls. It does not contact
+  the official Signal service.
 components:
   - workflow-plugin-signal
-  - wfctl pipeline run
+  - workflow-server
+  - HTTP trigger routes
   - Workflow external plugin loader
   - libsignal-go session/pre-key primitives
   - step.signal_session_prepare

--- a/scenarios/104-signal-e2e-encryption/test/run.sh
+++ b/scenarios/104-signal-e2e-encryption/test/run.sh
@@ -112,7 +112,11 @@ else
   exit 1
 fi
 
-DATA_DIR="$(mktemp -d)"
+if ! DATA_DIR="$(mktemp -d)"; then
+  fail "could not create temporary data directory"
+  finish
+  exit 1
+fi
 PLUGIN_DIR="$DATA_DIR/plugins"
 if build_plugin "$PLUGIN_DIR"; then
   pass "built workflow-plugin-signal external plugin"

--- a/scenarios/104-signal-e2e-encryption/test/run.sh
+++ b/scenarios/104-signal-e2e-encryption/test/run.sh
@@ -49,7 +49,7 @@ resolve_wfctl() {
   local workflow_repo
   workflow_repo="$(find_repo "${WORKFLOW_REPO:-}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
   mkdir -p "$workflow_repo/bin" || return 1
-  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null 2>&1 || return 1
   printf '%s\n' "$workflow_repo/bin/wfctl"
 }
 
@@ -62,7 +62,7 @@ build_plugin() {
   cp "$plugin_repo/plugin.json" "$plugin_dir/$PLUGIN_NAME/plugin.json" || return 1
   (cd "$plugin_repo" && GOWORK=off go build \
     -ldflags "-X github.com/GoCodeAlone/workflow-plugin-signal/internal.Version=${PLUGIN_VERSION:-0.0.0}" \
-    -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-signal) >/dev/null || return 1
+    -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-signal) >/dev/null 2>&1 || return 1
 }
 
 echo ""
@@ -109,7 +109,12 @@ echo "$OUTPUT" | grep -q 'Pipeline completed successfully' \
   && pass "Workflow engine reported successful pipeline completion" \
   || fail "Workflow engine did not report successful completion"
 
-echo "$OUTPUT" | grep -q "$PLAINTEXT_B64" \
+echo "$OUTPUT" | awk -v want="$PLAINTEXT_B64" '
+  /Step 5\/5: decrypt/ { in_step = 1; next }
+  /^Pipeline completed successfully/ { in_step = 0 }
+  in_step && index($0, "plaintext = " want) { found = 1 }
+  END { exit found ? 0 : 1 }
+' \
   && pass "decrypted plaintext flowed through Workflow pipeline output" \
   || fail "decrypted plaintext was not observed in Workflow output"
 

--- a/scenarios/104-signal-e2e-encryption/test/run.sh
+++ b/scenarios/104-signal-e2e-encryption/test/run.sh
@@ -1,63 +1,116 @@
 #!/usr/bin/env bash
-# Scenario 104 — Signal E2E Encryption.
+# Scenario 104 - Signal E2E Encryption.
 #
-# Demonstration-fidelity: this script runs the real released
-# workflow-plugin-signal v0.9.0 typed step tests. PASS/FAIL lines are derived
-# from `go test` output, not from hard-coded expected output.
+# Demonstration-fidelity: this executes a Workflow app pipeline with the real
+# workflow-plugin-signal subprocess loaded through wfctl's external plugin path.
 set -uo pipefail
 
-PLUGIN_VERSION="${PLUGIN_VERSION:-v0.9.0}"
-PKG="github.com/GoCodeAlone/workflow-plugin-signal/internal"
-TEST_RE='TestSignalSessionPrepareEncryptDecryptRoundTrip|TestSignalDecryptDeniesUnauthorizedPrincipalWithoutPlaintext'
+PLUGIN_NAME="workflow-plugin-signal"
+PLAINTEXT_B64="cHJpdmF0ZSB3b3JrZmxvdyBtZXNzYWdl"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+CONFIG="$SCENARIO_DIR/config/app.yaml"
 
 PASS=0
 FAIL=0
 pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
-
-echo ""
-echo "=== Scenario 104 — Signal E2E Encryption ==="
-echo ""
-
-if ! WORKDIR="$(mktemp -d)"; then
-  fail "could not create temporary module workspace"
+finish() {
   echo ""
   echo "Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ]
+}
+
+find_repo() {
+  local env_value="$1"
+  shift
+  if [ -n "$env_value" ]; then
+    [ -d "$env_value" ] && printf '%s\n' "$env_value" && return 0
+    return 1
+  fi
+  local candidate
+  for candidate in "$@"; do
+    if [ -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_wfctl() {
+  if [ -n "${WFCTL:-}" ]; then
+    [ -x "$WFCTL" ] && printf '%s\n' "$WFCTL" && return 0
+    return 1
+  fi
+
+  local workflow_repo
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  mkdir -p "$workflow_repo/bin" || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null || return 1
+  printf '%s\n' "$workflow_repo/bin/wfctl"
+}
+
+build_plugin() {
+  local plugin_dir="$1"
+  local plugin_repo
+  plugin_repo="$(find_repo "${SIGNAL_PLUGIN_REPO:-}" "$REPO_ROOT/../workflow-plugin-signal" "$REPO_ROOT/../../../workflow-plugin-signal")" || return 1
+
+  mkdir -p "$plugin_dir/$PLUGIN_NAME" || return 1
+  cp "$plugin_repo/plugin.json" "$plugin_dir/$PLUGIN_NAME/plugin.json" || return 1
+  (cd "$plugin_repo" && GOWORK=off go build \
+    -ldflags "-X github.com/GoCodeAlone/workflow-plugin-signal/internal.Version=${PLUGIN_VERSION:-0.0.0}" \
+    -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-signal) >/dev/null || return 1
+}
+
+echo ""
+echo "=== Scenario 104 - Signal E2E Encryption ==="
+echo ""
+
+[ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
+
+WFCTL_BIN="$(resolve_wfctl)"
+if [ "$?" -eq 0 ]; then
+  pass "wfctl binary is available"
+else
+  fail "wfctl binary unavailable; set WFCTL or WORKFLOW_REPO"
+  finish
   exit 1
 fi
-trap 'rm -rf "$WORKDIR"' EXIT
 
-(
-  cd "$WORKDIR" || exit 1
-  go mod init scenario-104-signal-e2e >/dev/null
-  go get "${PKG}@${PLUGIN_VERSION}" >/dev/null
-)
-if [ "$?" -eq 0 ]; then
-  pass "pinned workflow-plugin-signal ${PLUGIN_VERSION}"
+PLUGIN_DIR="$(mktemp -d)"
+trap 'rm -rf "$PLUGIN_DIR"' EXIT
+
+if build_plugin "$PLUGIN_DIR"; then
+  pass "built workflow-plugin-signal external plugin"
 else
-  fail "could not pin workflow-plugin-signal ${PLUGIN_VERSION}"
+  fail "could not build workflow-plugin-signal; set SIGNAL_PLUGIN_REPO"
+  finish
+  exit 1
 fi
 
-OUTPUT="$(
-  cd "$WORKDIR" && go test "$PKG" -run "$TEST_RE" -count=1 -v 2>&1
-)"
+OUTPUT="$("$WFCTL_BIN" pipeline run -c "$CONFIG" -p signal-e2e --plugin-dir "$PLUGIN_DIR" --verbose 2>&1)"
 STATUS=$?
 echo "$OUTPUT"
 
 if [ "$STATUS" -eq 0 ]; then
-  pass "released Signal plugin E2E encryption tests passed"
+  pass "wfctl pipeline run completed"
 else
-  fail "released Signal plugin E2E encryption tests failed"
+  fail "wfctl pipeline run failed"
 fi
 
-echo "$OUTPUT" | grep -q 'TestSignalSessionPrepareEncryptDecryptRoundTrip' \
-  && pass "session prepare -> encrypt -> decrypt round trip executed" \
-  || fail "round-trip test did not execute"
+echo "$OUTPUT" | grep -q 'Pipeline completed successfully' \
+  && pass "Workflow engine reported successful pipeline completion" \
+  || fail "Workflow engine did not report successful completion"
 
-echo "$OUTPUT" | grep -q 'TestSignalDecryptDeniesUnauthorizedPrincipalWithoutPlaintext' \
-  && pass "unauthorized principal denial executed" \
-  || fail "unauthorized principal denial test did not execute"
+echo "$OUTPUT" | grep -q "$PLAINTEXT_B64" \
+  && pass "decrypted plaintext flowed through Workflow pipeline output" \
+  || fail "decrypted plaintext was not observed in Workflow output"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ] && exit 0 || exit 1
+echo "$OUTPUT" | grep -q 'Step 5/5: decrypt' \
+  && pass "Signal decrypt step executed through plugin" \
+  || fail "Signal decrypt step was not observed"
+
+finish

--- a/scenarios/104-signal-e2e-encryption/test/run.sh
+++ b/scenarios/104-signal-e2e-encryption/test/run.sh
@@ -80,7 +80,11 @@ else
   exit 1
 fi
 
-PLUGIN_DIR="$(mktemp -d)"
+if ! PLUGIN_DIR="$(mktemp -d)"; then
+  fail "could not create temporary plugin directory"
+  finish
+  exit 1
+fi
 trap 'rm -rf "$PLUGIN_DIR"' EXIT
 
 if build_plugin "$PLUGIN_DIR"; then

--- a/scenarios/104-signal-e2e-encryption/test/run.sh
+++ b/scenarios/104-signal-e2e-encryption/test/run.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Scenario 104 - Signal E2E Encryption.
 #
-# Demonstration-fidelity: this executes a Workflow app pipeline with the real
-# workflow-plugin-signal subprocess loaded through wfctl's external plugin path.
+# Demonstration-fidelity: this starts the real Workflow server, loads the real
+# workflow-plugin-signal subprocess from data/plugins, and drives independent
+# HTTP clients through participant-parametric API routes.
 set -uo pipefail
 
 PLUGIN_NAME="workflow-plugin-signal"
-PLAINTEXT_B64="cHJpdmF0ZSB3b3JrZmxvdyBtZXNzYWdl"
+CLIENT_A="${CLIENT_A:-user-a}"
+CLIENT_B="${CLIENT_B:-user-b}"
+PLAINTEXT_B64="${PLAINTEXT_B64:-cHJpdmF0ZSB3b3JrZmxvdyBtZXNzYWdl}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:18104}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -15,6 +19,8 @@ CONFIG="$SCENARIO_DIR/config/app.yaml"
 
 PASS=0
 FAIL=0
+SERVER_PID=""
+DATA_DIR=""
 pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
 finish() {
@@ -22,6 +28,14 @@ finish() {
   echo "Results: $PASS passed, $FAIL failed"
   [ "$FAIL" -eq 0 ]
 }
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  [ -n "$DATA_DIR" ] && rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
 
 find_repo() {
   local env_value="$1"
@@ -40,17 +54,17 @@ find_repo() {
   return 1
 }
 
-resolve_wfctl() {
-  if [ -n "${WFCTL:-}" ]; then
-    [ -x "$WFCTL" ] && printf '%s\n' "$WFCTL" && return 0
+resolve_server() {
+  if [ -n "${WORKFLOW_SERVER:-}" ]; then
+    [ -x "$WORKFLOW_SERVER" ] && printf '%s\n' "$WORKFLOW_SERVER" && return 0
     return 1
   fi
 
   local workflow_repo
-  workflow_repo="$(find_repo "${WORKFLOW_REPO:-}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-${WORKFLOW_DIR:-}}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
   mkdir -p "$workflow_repo/bin" || return 1
-  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null 2>&1 || return 1
-  printf '%s\n' "$workflow_repo/bin/wfctl"
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/workflow-server ./cmd/server) >/dev/null 2>&1 || return 1
+  printf '%s\n' "$workflow_repo/bin/workflow-server"
 }
 
 build_plugin() {
@@ -65,28 +79,41 @@ build_plugin() {
     -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-signal) >/dev/null 2>&1 || return 1
 }
 
+wait_for_server() {
+  local url="$1"
+  local i
+  for i in $(seq 1 80); do
+    curl -fs "$url/healthz" >/dev/null 2>&1 && return 0
+    if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
 echo ""
 echo "=== Scenario 104 - Signal E2E Encryption ==="
 echo ""
 
 [ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
-
-WFCTL_BIN="$(resolve_wfctl)"
-if [ "$?" -eq 0 ]; then
-  pass "wfctl binary is available"
+if grep -Eiq 'alice|bob' "$CONFIG"; then
+  fail "Workflow pipelines should not hard-code Alice/Bob participant names"
 else
-  fail "wfctl binary unavailable; set WFCTL or WORKFLOW_REPO"
+  pass "Workflow API is participant-parametric"
+fi
+
+SERVER_BIN="$(resolve_server)"
+if [ "$?" -eq 0 ]; then
+  pass "workflow server binary is available"
+else
+  fail "workflow server unavailable; set WORKFLOW_SERVER or WORKFLOW_REPO"
   finish
   exit 1
 fi
 
-if ! PLUGIN_DIR="$(mktemp -d)"; then
-  fail "could not create temporary plugin directory"
-  finish
-  exit 1
-fi
-trap 'rm -rf "$PLUGIN_DIR"' EXIT
-
+DATA_DIR="$(mktemp -d)"
+PLUGIN_DIR="$DATA_DIR/plugins"
 if build_plugin "$PLUGIN_DIR"; then
   pass "built workflow-plugin-signal external plugin"
 else
@@ -95,31 +122,60 @@ else
   exit 1
 fi
 
-OUTPUT="$("$WFCTL_BIN" pipeline run -c "$CONFIG" -p signal-e2e --plugin-dir "$PLUGIN_DIR" --verbose 2>&1)"
-STATUS=$?
-echo "$OUTPUT"
+SERVER_LOG="$SCRIPT_DIR/artifacts/last-server.log"
+mkdir -p "$(dirname "$SERVER_LOG")"
+"$SERVER_BIN" -config "$CONFIG" -data-dir "$DATA_DIR" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
 
-if [ "$STATUS" -eq 0 ]; then
-  pass "wfctl pipeline run completed"
+if wait_for_server "$BASE_URL"; then
+  pass "workflow server started and served /healthz"
 else
-  fail "wfctl pipeline run failed"
+  fail "workflow server did not become ready; see $SERVER_LOG"
+  finish
+  exit 1
 fi
 
-echo "$OUTPUT" | grep -q 'Pipeline completed successfully' \
-  && pass "Workflow engine reported successful pipeline completion" \
-  || fail "Workflow engine did not report successful completion"
+SESSION_B="$(curl -fsS -X POST "$BASE_URL/participants/$CLIENT_B/session" -H 'Content-Type: application/json' -d '{}')" \
+  && pass "client B published a pre-key bundle via Workflow API" \
+  || fail "client B session prepare API failed"
 
-echo "$OUTPUT" | awk -v want="$PLAINTEXT_B64" '
-  /Step 5\/5: decrypt/ { in_step = 1; next }
-  /^Pipeline completed successfully/ { in_step = 0 }
-  in_step && index($0, "plaintext = " want) { found = 1 }
-  END { exit found ? 0 : 1 }
-' \
-  && pass "decrypted plaintext flowed through Workflow pipeline output" \
-  || fail "decrypted plaintext was not observed in Workflow output"
+BUNDLE="$(printf '%s' "$SESSION_B" | jq -c '.bundle // empty' 2>/dev/null)"
+if [ -n "$BUNDLE" ] && [ "$BUNDLE" != "null" ]; then
+  pass "client B response contained a bundle"
+else
+  fail "client B response did not contain a bundle: $SESSION_B"
+fi
 
-echo "$OUTPUT" | grep -q 'Step 5/5: decrypt' \
-  && pass "Signal decrypt step executed through plugin" \
-  || fail "Signal decrypt step was not observed"
+ENCRYPT_BODY="$(jq -cn --arg plaintext "$PLAINTEXT_B64" --argjson remote_bundle "$BUNDLE" \
+  '{plaintext:$plaintext, remote_bundle:$remote_bundle}')" || ENCRYPT_BODY=""
+ENCRYPTED="$(curl -fsS -X POST "$BASE_URL/participants/$CLIENT_A/messages" -H 'Content-Type: application/json' -d "$ENCRYPT_BODY")" \
+  && pass "client A encrypted a message to client B through Workflow API" \
+  || fail "client A encrypt API failed"
+
+ENVELOPE="$(printf '%s' "$ENCRYPTED" | jq -c '.envelope // empty' 2>/dev/null)"
+if [ -n "$ENVELOPE" ] && [ "$ENVELOPE" != "null" ]; then
+  pass "client A response contained an encrypted envelope"
+else
+  fail "client A response did not contain an envelope: $ENCRYPTED"
+fi
+
+if printf '%s' "$ENVELOPE" | grep -q "$PLAINTEXT_B64"; then
+  fail "encrypted envelope leaked plaintext"
+else
+  pass "encrypted envelope did not contain plaintext"
+fi
+
+DECRYPT_BODY="$(jq -cn --arg principal "$CLIENT_B" --argjson envelope "$ENVELOPE" \
+  '{principal:$principal, envelope:$envelope}')" || DECRYPT_BODY=""
+DECRYPTED="$(curl -fsS -X POST "$BASE_URL/participants/$CLIENT_B/messages/decrypt" -H 'Content-Type: application/json' -d "$DECRYPT_BODY")" \
+  && pass "client B decrypted client A message through Workflow API" \
+  || fail "client B decrypt API failed"
+
+GOT="$(printf '%s' "$DECRYPTED" | jq -r '.plaintext // empty' 2>/dev/null)"
+if [ "$GOT" = "$PLAINTEXT_B64" ]; then
+  pass "client B recovered the original plaintext"
+else
+  fail "client B plaintext mismatch: got '$GOT'"
+fi
 
 finish

--- a/scenarios/105-encrypted-spaces-proof-workflow/README.md
+++ b/scenarios/105-encrypted-spaces-proof-workflow/README.md
@@ -6,15 +6,16 @@ running Workflow API.
 
 The scenario builds `workflow-plugin-encrypted-spaces`, loads it as an external
 Workflow plugin under a temporary `data/plugins` directory, launches the real
-Workflow server, and drives space-parametric HTTP routes:
+Workflow server, and drives fixture-backed HTTP routes:
 
 - a client appends an encrypted operation via `POST /spaces/{space}/operations`
 - a proof client verifies the returned commitment via `POST /spaces/{space}/proof`
 
-The app uses an in-memory encrypted-space store. Operation IDs, member IDs,
-encrypted payloads, expected commitments, membership proof vectors, and
-checkpoint proof vectors are request inputs, not baked into the workflow
-pipeline.
+The app uses an in-memory encrypted-space store. The route path, operation ID,
+encrypted payload, expected commitment, membership proof vector, and checkpoint
+proof vector are request inputs, not baked into the workflow pipeline. The
+proof digest fixture is intentionally bound to the `space-1`/`member-1`
+membership tuple.
 
 ## Running
 

--- a/scenarios/105-encrypted-spaces-proof-workflow/README.md
+++ b/scenarios/105-encrypted-spaces-proof-workflow/README.md
@@ -1,13 +1,20 @@
 # Scenario 105 - Encrypted Spaces Proof Workflow
 
 Local-only Workflow app proof that the Encrypted Spaces Workflow plugin can
-verify a proof-gated append flow and emit redacted proof evidence.
+verify a proof-gated append flow and emit redacted proof evidence through a
+running Workflow API.
 
 The scenario builds `workflow-plugin-encrypted-spaces`, loads it as an external
-Workflow plugin, and runs `config/app.yaml` with the Workflow engine. The app
-uses an in-memory encrypted-space store, appends an encrypted operation, verifies
-the expected commitment with membership and key-transparency vector evidence,
-and emits proof-evidence output.
+Workflow plugin under a temporary `data/plugins` directory, launches the real
+Workflow server, and drives space-parametric HTTP routes:
+
+- a client appends an encrypted operation via `POST /spaces/{space}/operations`
+- a proof client verifies the returned commitment via `POST /spaces/{space}/proof`
+
+The app uses an in-memory encrypted-space store. Operation IDs, member IDs,
+encrypted payloads, expected commitments, membership proof vectors, and
+checkpoint proof vectors are request inputs, not baked into the workflow
+pipeline.
 
 ## Running
 
@@ -15,7 +22,7 @@ and emits proof-evidence output.
 bash scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
 ```
 
-Set `WFCTL`, `WORKFLOW_REPO`, or `ENCRYPTED_SPACES_PLUGIN_REPO` when running
-outside the standard workspace layout.
+Set `WORKFLOW_SERVER`, `WORKFLOW_REPO`, or `ENCRYPTED_SPACES_PLUGIN_REPO` when
+running outside the standard workspace layout.
 
 No S3 bucket or live external service egress is used.

--- a/scenarios/105-encrypted-spaces-proof-workflow/README.md
+++ b/scenarios/105-encrypted-spaces-proof-workflow/README.md
@@ -1,20 +1,13 @@
-# Scenario 105 — Encrypted Spaces Proof Workflow
+# Scenario 105 - Encrypted Spaces Proof Workflow
 
-Local-only proof that the released Encrypted Spaces Workflow plugin can verify a
-proof-gated append flow and emit redacted proof evidence.
+Local-only Workflow app proof that the Encrypted Spaces Workflow plugin can
+verify a proof-gated append flow and emit redacted proof evidence.
 
-The scenario creates a temporary Go module, pins
-`github.com/GoCodeAlone/workflow-plugin-encrypted-spaces@v0.4.0`, then runs the
-released plugin's focused proof workflow tests:
-
-- `TestAppendVerifiedAcceptsVectorBackedProof`
-- `TestAppendVerifiedRejectsTamperedProof`
-- `TestProofEvidenceRedactsPlaintextAndKeyMaterial`
-- `TestVectorReportStepFiltersRequiredDomains`
-
-Those tests execute the actual Workflow plugin step implementations for
-vector-backed append verification, tamper rejection, coverage filtering, and
-proof-evidence redaction.
+The scenario builds `workflow-plugin-encrypted-spaces`, loads it as an external
+Workflow plugin, and runs `config/app.yaml` with the Workflow engine. The app
+uses an in-memory encrypted-space store, appends an encrypted operation, verifies
+the expected commitment with membership and key-transparency vector evidence,
+and emits proof-evidence output.
 
 ## Running
 
@@ -22,4 +15,7 @@ proof-evidence redaction.
 bash scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
 ```
 
-No live external service egress is used.
+Set `WFCTL`, `WORKFLOW_REPO`, or `ENCRYPTED_SPACES_PLUGIN_REPO` when running
+outside the standard workspace layout.
+
+No S3 bucket or live external service egress is used.

--- a/scenarios/105-encrypted-spaces-proof-workflow/config/app.yaml
+++ b/scenarios/105-encrypted-spaces-proof-workflow/config/app.yaml
@@ -1,10 +1,20 @@
 modules:
+  - name: server
+    type: http.server
+    config:
+      address: ":18105"
+
+  - name: router
+    type: http.router
+    dependsOn: [server]
+
   - name: encrypted_space_store
     type: encrypted_space.store
     config:
       space_id: space-1
       backend: memory
       max_operations: 128
+
   - name: encrypted_space_policy
     type: encrypted_space.proof_policy
     config:
@@ -14,96 +24,81 @@ modules:
         - message-backup
         - svr-svrb
 
+workflows:
+  http:
+    server: server
+    router: router
+
 pipelines:
-  encrypted-space-proof:
+  healthz:
+    trigger: { type: http, config: { path: /healthz, method: GET } }
     steps:
-      - name: operation_input
-        type: step.set
+      - name: ok
+        type: step.json_response
         config:
-          values:
-            operation:
-              space_id: space-1
-              member_id: member-1
-              device_id: device-1
-              operation_id: verified-op
-              key_epoch: 1
-              membership_epoch: 1
-              ciphertext: c2VhbGVkLWNvbGxhYi1wYXlsb2Fk
-              nonce: bm9uY2UtMTIzNDU2Nzg5MDEy
-              associated_data: c3BhY2UtMS9yb29tLTE=
-              created_at_unix_nano: 1783000000000000000
+          status: 200
+          body: { status: ok, scenario: "105-encrypted-spaces-proof-workflow" }
+
+  append-operation:
+    trigger:
+      type: http
+      config:
+        path: /spaces/{space}/operations
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [space]
+          parse_body: true
+          merge_body: true
       - name: append
         type: step.encrypted_space_append
         config:
           allow_fake_verifier: true
           retention:
             max_operations: 10
-      - name: verified_input
-        type: step.set
+      - name: respond
+        type: step.json_response
         config:
-          values:
-            operation:
-              space_id: space-1
-              member_id: member-1
-              device_id: device-1
-              operation_id: verified-op
-              key_epoch: 1
-              membership_epoch: 1
-              ciphertext: c2VhbGVkLWNvbGxhYi1wYXlsb2Fk
-              nonce: bm9uY2UtMTIzNDU2Nzg5MDEy
-              associated_data: c3BhY2UtMS9yb29tLTE=
-              created_at_unix_nano: 1783000000000000000
-            expected_commitment:
-              space_id: "{{ index .steps \"append\" \"commitment\" \"space_id\" }}"
-              operation_id: "{{ index .steps \"append\" \"commitment\" \"operation_id\" }}"
-              sequence: "{{ index .steps \"append\" \"commitment\" \"sequence\" }}"
-              digest: "{{ index .steps \"append\" \"commitment\" \"digest\" }}"
-              key_epoch: "{{ index .steps \"append\" \"commitment\" \"key_epoch\" }}"
-              membership_epoch: "{{ index .steps \"append\" \"commitment\" \"membership_epoch\" }}"
-              ciphertext_size: "{{ index .steps \"append\" \"commitment\" \"ciphertext_size\" }}"
-            membership:
-              group_id: space-1
-              member_id: member-1
-              issuer: issuer-1
-              expires_at: 1893456000
-              proof_digest: sha256:2f99cb90ee710be078aaf1b8cb9a22942c10f5965e5e39c1607a930fd6df7874
-              upstream_path: java/shared/java/org/signal/libsignal/zkgroup/groups
-            checkpoint:
-              checkpoint_id: checkpoint-1
-              tree_head: tree-head-1
-              tree_size: 42
-              proof_digest: sha256:479338417f33b12df048fbe2180f58638636b2618d90ac6f807ed436ff881d8c
-              upstream_path: rust/keytrans/src/verify.rs
-              previous_tree_size: 0
+          status: 200
+          body:
+            space: '{{ index .steps "parse" "path_params" "space" }}'
+            commitment:
+              _from: steps.append.commitment
+    on_error: stop
+
+  verify-operation:
+    trigger:
+      type: http
+      config:
+        path: /spaces/{space}/proof
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [space]
+          parse_body: true
+          merge_body: true
       - name: append_verified
         type: step.encrypted_space_append_verified
         config:
           policy:
             require_vector_backed: true
-      - name: evidence_input
-        type: step.set
-        config:
-          values:
-            commitment:
-              space_id: "{{ index .steps \"append_verified\" \"commitment\" \"space_id\" }}"
-              operation_id: "{{ index .steps \"append_verified\" \"commitment\" \"operation_id\" }}"
-              sequence: "{{ index .steps \"append_verified\" \"commitment\" \"sequence\" }}"
-              digest: "{{ index .steps \"append_verified\" \"commitment\" \"digest\" }}"
-              key_epoch: "{{ index .steps \"append_verified\" \"commitment\" \"key_epoch\" }}"
-              membership_epoch: "{{ index .steps \"append_verified\" \"commitment\" \"membership_epoch\" }}"
-              ciphertext_size: "{{ index .steps \"append_verified\" \"commitment\" \"ciphertext_size\" }}"
-            reports:
-              - domain: operationlog.commitment
-                accepted: true
-                production_ready: true
-              - domain: zkgroup.membership
-                accepted: true
-                production_ready: true
-                upstream_path: java/shared/java/org/signal/libsignal/zkgroup/groups
-              - domain: keytrans.checkpoint
-                accepted: true
-                production_ready: true
-                upstream_path: rust/keytrans/src/verify.rs
       - name: proof_evidence
         type: step.encrypted_space_proof_evidence
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            space: '{{ index .steps "parse" "path_params" "space" }}'
+            commitment:
+              _from: steps.append_verified.commitment
+            reports:
+              _from: steps.append_verified.reports
+            evidence:
+              _from: steps.proof_evidence.evidence
+            json: "{{ .steps.proof_evidence.json }}"
     on_error: stop

--- a/scenarios/105-encrypted-spaces-proof-workflow/config/app.yaml
+++ b/scenarios/105-encrypted-spaces-proof-workflow/config/app.yaml
@@ -1,0 +1,109 @@
+modules:
+  - name: encrypted_space_store
+    type: encrypted_space.store
+    config:
+      space_id: space-1
+      backend: memory
+      max_operations: 128
+  - name: encrypted_space_policy
+    type: encrypted_space.proof_policy
+    config:
+      mode: vector-backed
+      require_vector_backed: true
+      deferred_domains:
+        - message-backup
+        - svr-svrb
+
+pipelines:
+  encrypted-space-proof:
+    steps:
+      - name: operation_input
+        type: step.set
+        config:
+          values:
+            operation:
+              space_id: space-1
+              member_id: member-1
+              device_id: device-1
+              operation_id: verified-op
+              key_epoch: 1
+              membership_epoch: 1
+              ciphertext: c2VhbGVkLWNvbGxhYi1wYXlsb2Fk
+              nonce: bm9uY2UtMTIzNDU2Nzg5MDEy
+              associated_data: c3BhY2UtMS9yb29tLTE=
+              created_at_unix_nano: 1783000000000000000
+      - name: append
+        type: step.encrypted_space_append
+        config:
+          allow_fake_verifier: true
+          retention:
+            max_operations: 10
+      - name: verified_input
+        type: step.set
+        config:
+          values:
+            operation:
+              space_id: space-1
+              member_id: member-1
+              device_id: device-1
+              operation_id: verified-op
+              key_epoch: 1
+              membership_epoch: 1
+              ciphertext: c2VhbGVkLWNvbGxhYi1wYXlsb2Fk
+              nonce: bm9uY2UtMTIzNDU2Nzg5MDEy
+              associated_data: c3BhY2UtMS9yb29tLTE=
+              created_at_unix_nano: 1783000000000000000
+            expected_commitment:
+              space_id: "{{ index .steps \"append\" \"commitment\" \"space_id\" }}"
+              operation_id: "{{ index .steps \"append\" \"commitment\" \"operation_id\" }}"
+              sequence: "{{ index .steps \"append\" \"commitment\" \"sequence\" }}"
+              digest: "{{ index .steps \"append\" \"commitment\" \"digest\" }}"
+              key_epoch: "{{ index .steps \"append\" \"commitment\" \"key_epoch\" }}"
+              membership_epoch: "{{ index .steps \"append\" \"commitment\" \"membership_epoch\" }}"
+              ciphertext_size: "{{ index .steps \"append\" \"commitment\" \"ciphertext_size\" }}"
+            membership:
+              group_id: space-1
+              member_id: member-1
+              issuer: issuer-1
+              expires_at: 1893456000
+              proof_digest: sha256:2f99cb90ee710be078aaf1b8cb9a22942c10f5965e5e39c1607a930fd6df7874
+              upstream_path: java/shared/java/org/signal/libsignal/zkgroup/groups
+            checkpoint:
+              checkpoint_id: checkpoint-1
+              tree_head: tree-head-1
+              tree_size: 42
+              proof_digest: sha256:479338417f33b12df048fbe2180f58638636b2618d90ac6f807ed436ff881d8c
+              upstream_path: rust/keytrans/src/verify.rs
+              previous_tree_size: 0
+      - name: append_verified
+        type: step.encrypted_space_append_verified
+        config:
+          policy:
+            require_vector_backed: true
+      - name: evidence_input
+        type: step.set
+        config:
+          values:
+            commitment:
+              space_id: "{{ index .steps \"append_verified\" \"commitment\" \"space_id\" }}"
+              operation_id: "{{ index .steps \"append_verified\" \"commitment\" \"operation_id\" }}"
+              sequence: "{{ index .steps \"append_verified\" \"commitment\" \"sequence\" }}"
+              digest: "{{ index .steps \"append_verified\" \"commitment\" \"digest\" }}"
+              key_epoch: "{{ index .steps \"append_verified\" \"commitment\" \"key_epoch\" }}"
+              membership_epoch: "{{ index .steps \"append_verified\" \"commitment\" \"membership_epoch\" }}"
+              ciphertext_size: "{{ index .steps \"append_verified\" \"commitment\" \"ciphertext_size\" }}"
+            reports:
+              - domain: operationlog.commitment
+                accepted: true
+                production_ready: true
+              - domain: zkgroup.membership
+                accepted: true
+                production_ready: true
+                upstream_path: java/shared/java/org/signal/libsignal/zkgroup/groups
+              - domain: keytrans.checkpoint
+                accepted: true
+                production_ready: true
+                upstream_path: rust/keytrans/src/verify.rs
+      - name: proof_evidence
+        type: step.encrypted_space_proof_evidence
+    on_error: stop

--- a/scenarios/105-encrypted-spaces-proof-workflow/config/app.yaml
+++ b/scenarios/105-encrypted-spaces-proof-workflow/config/app.yaml
@@ -100,5 +100,6 @@ pipelines:
               _from: steps.append_verified.reports
             evidence:
               _from: steps.proof_evidence.evidence
-            json: "{{ .steps.proof_evidence.json }}"
+            json:
+              _from: steps.proof_evidence.evidence
     on_error: stop

--- a/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
+++ b/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
@@ -2,20 +2,23 @@ name: Encrypted Spaces Proof Workflow
 id: "105-encrypted-spaces-proof-workflow"
 category: C
 description: |
-  Local-only proof that the released Encrypted Spaces Workflow plugin verifies
-  a proof-gated append flow and emits redacted proof evidence.
+  Local-only Workflow app proof that the Encrypted Spaces Workflow plugin
+  verifies a proof-gated append flow and emits redacted proof evidence.
 
-  The scenario creates a temporary Go module, pins
-  workflow-plugin-encrypted-spaces v0.4.0, and runs the released plugin's
-  focused tests for vector-backed append verification, tamper rejection,
-  proof-evidence redaction, and required-domain vector coverage. This executes
-  the real plugin step implementations backed by encrypted-spaces-go.
+  The scenario builds workflow-plugin-encrypted-spaces as an external plugin,
+  loads it through wfctl, and runs config/app.yaml with the Workflow engine. The
+  app uses an in-memory encrypted-space store, verifies a commitment with
+  membership and key-transparency vector evidence, and emits proof evidence. It
+  does not use S3 or live external services.
 components:
-  - workflow-plugin-encrypted-spaces v0.4.0
+  - workflow-plugin-encrypted-spaces
+  - wfctl pipeline run
+  - Workflow external plugin loader
   - encrypted-spaces-go proof policy
+  - encrypted_space.store memory backend
+  - step.encrypted_space_append
   - step.encrypted_space_append_verified
   - step.encrypted_space_proof_evidence
-  - step.encrypted_space_vector_report
 status: testable
 tags:
   - encrypted-spaces

--- a/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
+++ b/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
@@ -9,8 +9,9 @@ description: |
   The scenario builds workflow-plugin-encrypted-spaces as an external plugin,
   loads it through the Workflow server's data/plugins path, and starts
   config/app.yaml with HTTP routes for appending encrypted operations and
-  verifying proof evidence. Operation IDs, member IDs, commitments, and vector
-  proof material are request inputs. It does not use S3 or live external
+  verifying proof evidence. Operation IDs, commitments, and vector proof
+  material are request inputs; the proof digest fixture is bound to the
+  space-1/member-1 membership tuple. It does not use S3 or live external
   services.
 components:
   - workflow-plugin-encrypted-spaces

--- a/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
+++ b/scenarios/105-encrypted-spaces-proof-workflow/scenario.yaml
@@ -3,16 +3,19 @@ id: "105-encrypted-spaces-proof-workflow"
 category: C
 description: |
   Local-only Workflow app proof that the Encrypted Spaces Workflow plugin
-  verifies a proof-gated append flow and emits redacted proof evidence.
+  verifies a proof-gated append flow and emits redacted proof evidence through
+  a running Workflow API.
 
   The scenario builds workflow-plugin-encrypted-spaces as an external plugin,
-  loads it through wfctl, and runs config/app.yaml with the Workflow engine. The
-  app uses an in-memory encrypted-space store, verifies a commitment with
-  membership and key-transparency vector evidence, and emits proof evidence. It
-  does not use S3 or live external services.
+  loads it through the Workflow server's data/plugins path, and starts
+  config/app.yaml with HTTP routes for appending encrypted operations and
+  verifying proof evidence. Operation IDs, member IDs, commitments, and vector
+  proof material are request inputs. It does not use S3 or live external
+  services.
 components:
   - workflow-plugin-encrypted-spaces
-  - wfctl pipeline run
+  - workflow-server
+  - HTTP trigger routes
   - Workflow external plugin loader
   - encrypted-spaces-go proof policy
   - encrypted_space.store memory backend

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -49,7 +49,7 @@ resolve_wfctl() {
   local workflow_repo
   workflow_repo="$(find_repo "${WORKFLOW_REPO:-}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
   mkdir -p "$workflow_repo/bin" || return 1
-  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null 2>&1 || return 1
   printf '%s\n' "$workflow_repo/bin/wfctl"
 }
 
@@ -62,7 +62,7 @@ build_plugin() {
   cp "$plugin_repo/plugin.json" "$plugin_dir/$PLUGIN_NAME/plugin.json" || return 1
   (cd "$plugin_repo" && GOWORK=off go build \
     -ldflags "-X github.com/GoCodeAlone/workflow-plugin-encrypted-spaces/internal.Version=${PLUGIN_VERSION:-0.0.0}" \
-    -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-encrypted-spaces) >/dev/null || return 1
+    -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-encrypted-spaces) >/dev/null 2>&1 || return 1
 }
 
 echo ""
@@ -109,15 +109,20 @@ echo "$OUTPUT" | grep -q 'Pipeline completed successfully' \
   && pass "Workflow engine reported successful pipeline completion" \
   || fail "Workflow engine did not report successful completion"
 
-echo "$OUTPUT" | grep -q 'append_verified' \
+echo "$OUTPUT" | grep -q 'Step 4/6: append_verified' \
   && pass "verified append step executed through plugin" \
   || fail "verified append step was not observed"
 
-echo "$OUTPUT" | grep -q 'proof_evidence' \
+echo "$OUTPUT" | grep -q 'Step 6/6: proof_evidence' \
   && pass "proof evidence step executed through plugin" \
   || fail "proof evidence step was not observed"
 
-echo "$OUTPUT" | grep -q 'operationlog.commitment' \
+echo "$OUTPUT" | awk '
+  /Step 6\/6: proof_evidence/ { in_step = 1; next }
+  /^Pipeline completed successfully/ { in_step = 0 }
+  in_step && /operationlog\.commitment/ { found = 1 }
+  END { exit found ? 0 : 1 }
+' \
   && pass "proof report domains flowed through Workflow output" \
   || fail "proof report domains were not observed"
 

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 # Scenario 105 - Encrypted Spaces Proof Workflow.
 #
-# Demonstration-fidelity: this executes a Workflow app pipeline with the real
-# workflow-plugin-encrypted-spaces subprocess loaded through wfctl's external
-# plugin path. Storage is an in-memory plugin module, not S3.
+# Demonstration-fidelity: this starts the real Workflow server, loads the real
+# workflow-plugin-encrypted-spaces subprocess from data/plugins, and drives a
+# space/member API through separate HTTP calls. Storage is an in-memory plugin
+# module, not S3.
 set -uo pipefail
 
 PLUGIN_NAME="workflow-plugin-encrypted-spaces"
+BASE_URL="${BASE_URL:-http://127.0.0.1:18105}"
+SPACE_ID="${SPACE_ID:-space-1}"
+MEMBER_ID="${MEMBER_ID:-member-1}"
+DEVICE_ID="${DEVICE_ID:-device-1}"
+OPERATION_ID="${OPERATION_ID:-verified-op}"
+MEMBERSHIP_DIGEST="sha256:2f99cb90ee710be078aaf1b8cb9a22942c10f5965e5e39c1607a930fd6df7874"
+CHECKPOINT_DIGEST="sha256:479338417f33b12df048fbe2180f58638636b2618d90ac6f807ed436ff881d8c"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -15,6 +23,8 @@ CONFIG="$SCENARIO_DIR/config/app.yaml"
 
 PASS=0
 FAIL=0
+SERVER_PID=""
+DATA_DIR=""
 pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
 finish() {
@@ -22,6 +32,14 @@ finish() {
   echo "Results: $PASS passed, $FAIL failed"
   [ "$FAIL" -eq 0 ]
 }
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  [ -n "$DATA_DIR" ] && rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
 
 find_repo() {
   local env_value="$1"
@@ -40,17 +58,17 @@ find_repo() {
   return 1
 }
 
-resolve_wfctl() {
-  if [ -n "${WFCTL:-}" ]; then
-    [ -x "$WFCTL" ] && printf '%s\n' "$WFCTL" && return 0
+resolve_server() {
+  if [ -n "${WORKFLOW_SERVER:-}" ]; then
+    [ -x "$WORKFLOW_SERVER" ] && printf '%s\n' "$WORKFLOW_SERVER" && return 0
     return 1
   fi
 
   local workflow_repo
-  workflow_repo="$(find_repo "${WORKFLOW_REPO:-}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-${WORKFLOW_DIR:-}}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
   mkdir -p "$workflow_repo/bin" || return 1
-  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null 2>&1 || return 1
-  printf '%s\n' "$workflow_repo/bin/wfctl"
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/workflow-server ./cmd/server) >/dev/null 2>&1 || return 1
+  printf '%s\n' "$workflow_repo/bin/workflow-server"
 }
 
 build_plugin() {
@@ -65,28 +83,41 @@ build_plugin() {
     -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-encrypted-spaces) >/dev/null 2>&1 || return 1
 }
 
+wait_for_server() {
+  local url="$1"
+  local i
+  for i in $(seq 1 80); do
+    curl -fs "$url/healthz" >/dev/null 2>&1 && return 0
+    if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
 echo ""
 echo "=== Scenario 105 - Encrypted Spaces Proof Workflow ==="
 echo ""
 
 [ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
-
-WFCTL_BIN="$(resolve_wfctl)"
-if [ "$?" -eq 0 ]; then
-  pass "wfctl binary is available"
+if grep -q 'operation_id: verified-op' "$CONFIG"; then
+  fail "Workflow pipelines should not hard-code the scenario operation id"
 else
-  fail "wfctl binary unavailable; set WFCTL or WORKFLOW_REPO"
+  pass "Workflow API accepts operation/proof inputs from clients"
+fi
+
+SERVER_BIN="$(resolve_server)"
+if [ "$?" -eq 0 ]; then
+  pass "workflow server binary is available"
+else
+  fail "workflow server unavailable; set WORKFLOW_SERVER or WORKFLOW_REPO"
   finish
   exit 1
 fi
 
-if ! PLUGIN_DIR="$(mktemp -d)"; then
-  fail "could not create temporary plugin directory"
-  finish
-  exit 1
-fi
-trap 'rm -rf "$PLUGIN_DIR"' EXIT
-
+DATA_DIR="$(mktemp -d)"
+PLUGIN_DIR="$DATA_DIR/plugins"
 if build_plugin "$PLUGIN_DIR"; then
   pass "built workflow-plugin-encrypted-spaces external plugin"
 else
@@ -95,35 +126,69 @@ else
   exit 1
 fi
 
-OUTPUT="$("$WFCTL_BIN" pipeline run -c "$CONFIG" -p encrypted-space-proof --plugin-dir "$PLUGIN_DIR" --verbose 2>&1)"
-STATUS=$?
-echo "$OUTPUT"
+SERVER_LOG="$SCRIPT_DIR/artifacts/last-server.log"
+mkdir -p "$(dirname "$SERVER_LOG")"
+"$SERVER_BIN" -config "$CONFIG" -data-dir "$DATA_DIR" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
 
-if [ "$STATUS" -eq 0 ]; then
-  pass "wfctl pipeline run completed"
+if wait_for_server "$BASE_URL"; then
+  pass "workflow server started and served /healthz"
 else
-  fail "wfctl pipeline run failed"
+  fail "workflow server did not become ready; see $SERVER_LOG"
+  finish
+  exit 1
 fi
 
-echo "$OUTPUT" | grep -q 'Pipeline completed successfully' \
-  && pass "Workflow engine reported successful pipeline completion" \
-  || fail "Workflow engine did not report successful completion"
+OPERATION="$(jq -cn \
+  --arg space "$SPACE_ID" \
+  --arg member "$MEMBER_ID" \
+  --arg device "$DEVICE_ID" \
+  --arg operation "$OPERATION_ID" \
+  '{operation:{space_id:$space,member_id:$member,device_id:$device,operation_id:$operation,key_epoch:1,membership_epoch:1,ciphertext:"c2VhbGVkLWNvbGxhYi1wYXlsb2Fk",nonce:"bm9uY2UtMTIzNDU2Nzg5MDEy",associated_data:"c3BhY2UtMS9yb29tLTE=",created_at_unix_nano:1783000000000000000}}')" || OPERATION=""
+APPENDED="$(curl -fsS -X POST "$BASE_URL/spaces/$SPACE_ID/operations" -H 'Content-Type: application/json' -d "$OPERATION")" \
+  && pass "client appended an encrypted operation through Workflow API" \
+  || fail "operation append API failed"
 
-echo "$OUTPUT" | grep -q 'Step 4/6: append_verified' \
-  && pass "verified append step executed through plugin" \
-  || fail "verified append step was not observed"
+COMMITMENT="$(printf '%s' "$APPENDED" | jq -c '.commitment // empty' 2>/dev/null)"
+if [ -n "$COMMITMENT" ] && [ "$COMMITMENT" != "null" ]; then
+  pass "append response contained an operation commitment"
+else
+  fail "append response did not contain a commitment: $APPENDED"
+fi
 
-echo "$OUTPUT" | grep -q 'Step 6/6: proof_evidence' \
-  && pass "proof evidence step executed through plugin" \
-  || fail "proof evidence step was not observed"
+PROOF_REQUEST="$(jq -cn \
+  --argjson operation "$(printf '%s' "$OPERATION" | jq -c '.operation')" \
+  --argjson expected_commitment "$COMMITMENT" \
+  --arg member "$MEMBER_ID" \
+  --arg membership_digest "$MEMBERSHIP_DIGEST" \
+  --arg checkpoint_digest "$CHECKPOINT_DIGEST" \
+  '{operation:$operation,expected_commitment:$expected_commitment,membership:{group_id:"space-1",member_id:$member,issuer:"issuer-1",expires_at:1893456000,proof_digest:$membership_digest,upstream_path:"java/shared/java/org/signal/libsignal/zkgroup/groups"},checkpoint:{checkpoint_id:"checkpoint-1",tree_head:"tree-head-1",tree_size:42,proof_digest:$checkpoint_digest,upstream_path:"rust/keytrans/src/verify.rs",previous_tree_size:0}}')" || PROOF_REQUEST=""
+PROOF="$(curl -fsS -X POST "$BASE_URL/spaces/$SPACE_ID/proof" -H 'Content-Type: application/json' -d "$PROOF_REQUEST")" \
+  && pass "proof client verified the operation through Workflow API" \
+  || fail "proof verification API failed"
 
-echo "$OUTPUT" | awk '
-  /Step 6\/6: proof_evidence/ { in_step = 1; next }
-  /^Pipeline completed successfully/ { in_step = 0 }
-  in_step && /operationlog\.commitment/ { found = 1 }
-  END { exit found ? 0 : 1 }
-' \
-  && pass "proof report domains flowed through Workflow output" \
-  || fail "proof report domains were not observed"
+if printf '%s' "$PROOF" | jq -e '.reports[] | select(.domain=="operationlog.commitment" and .accepted==true)' >/dev/null 2>&1; then
+  pass "proof response contains accepted operationlog commitment report"
+else
+  fail "proof response missing accepted operationlog report: $PROOF"
+fi
+
+if printf '%s' "$PROOF" | jq -e '.reports[] | select(.domain=="zkgroup.membership" and .production_ready==true)' >/dev/null 2>&1; then
+  pass "proof response contains vector-backed membership report"
+else
+  fail "proof response missing vector-backed membership report: $PROOF"
+fi
+
+if printf '%s' "$PROOF" | jq -e '.json.reports[] | select(.domain=="operationlog.commitment")' >/dev/null 2>&1; then
+  pass "redacted proof evidence JSON was returned by the app"
+else
+  fail "proof evidence JSON missing operationlog domain: $PROOF"
+fi
+
+if printf '%s' "$PROOF" | grep -q 'c2VhbGVkLWNvbGxhYi1wYXlsb2Fk'; then
+  fail "proof response leaked ciphertext payload"
+else
+  pass "proof response did not leak ciphertext payload"
+fi
 
 finish

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -117,7 +117,11 @@ else
   exit 1
 fi
 
-DATA_DIR="$(mktemp -d)"
+if ! DATA_DIR="$(mktemp -d)"; then
+  fail "could not create temporary data directory"
+  finish
+  exit 1
+fi
 PLUGIN_DIR="$DATA_DIR/plugins"
 if build_plugin "$PLUGIN_DIR"; then
   pass "built workflow-plugin-encrypted-spaces external plugin"

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -9,8 +9,9 @@ set -uo pipefail
 
 PLUGIN_NAME="workflow-plugin-encrypted-spaces"
 BASE_URL="${BASE_URL:-http://127.0.0.1:18105}"
-SPACE_ID="${SPACE_ID:-space-1}"
-MEMBER_ID="${MEMBER_ID:-member-1}"
+# The proof digests below are fixture vectors for this space/member tuple.
+SPACE_ID="space-1"
+MEMBER_ID="member-1"
 DEVICE_ID="${DEVICE_ID:-device-1}"
 OPERATION_ID="${OPERATION_ID:-verified-op}"
 MEMBERSHIP_DIGEST="sha256:2f99cb90ee710be078aaf1b8cb9a22942c10f5965e5e39c1607a930fd6df7874"
@@ -159,10 +160,11 @@ fi
 PROOF_REQUEST="$(jq -cn \
   --argjson operation "$(printf '%s' "$OPERATION" | jq -c '.operation')" \
   --argjson expected_commitment "$COMMITMENT" \
+  --arg space "$SPACE_ID" \
   --arg member "$MEMBER_ID" \
   --arg membership_digest "$MEMBERSHIP_DIGEST" \
   --arg checkpoint_digest "$CHECKPOINT_DIGEST" \
-  '{operation:$operation,expected_commitment:$expected_commitment,membership:{group_id:"space-1",member_id:$member,issuer:"issuer-1",expires_at:1893456000,proof_digest:$membership_digest,upstream_path:"java/shared/java/org/signal/libsignal/zkgroup/groups"},checkpoint:{checkpoint_id:"checkpoint-1",tree_head:"tree-head-1",tree_size:42,proof_digest:$checkpoint_digest,upstream_path:"rust/keytrans/src/verify.rs",previous_tree_size:0}}')" || PROOF_REQUEST=""
+  '{operation:$operation,expected_commitment:$expected_commitment,membership:{group_id:$space,member_id:$member,issuer:"issuer-1",expires_at:1893456000,proof_digest:$membership_digest,upstream_path:"java/shared/java/org/signal/libsignal/zkgroup/groups"},checkpoint:{checkpoint_id:"checkpoint-1",tree_head:"tree-head-1",tree_size:42,proof_digest:$checkpoint_digest,upstream_path:"rust/keytrans/src/verify.rs",previous_tree_size:0}}')" || PROOF_REQUEST=""
 PROOF="$(curl -fsS -X POST "$BASE_URL/spaces/$SPACE_ID/proof" -H 'Content-Type: application/json' -d "$PROOF_REQUEST")" \
   && pass "proof client verified the operation through Workflow API" \
   || fail "proof verification API failed"

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -80,7 +80,11 @@ else
   exit 1
 fi
 
-PLUGIN_DIR="$(mktemp -d)"
+if ! PLUGIN_DIR="$(mktemp -d)"; then
+  fail "could not create temporary plugin directory"
+  finish
+  exit 1
+fi
 trap 'rm -rf "$PLUGIN_DIR"' EXIT
 
 if build_plugin "$PLUGIN_DIR"; then

--- a/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
+++ b/scenarios/105-encrypted-spaces-proof-workflow/test/run.sh
@@ -1,71 +1,120 @@
 #!/usr/bin/env bash
-# Scenario 105 — Encrypted Spaces Proof Workflow.
+# Scenario 105 - Encrypted Spaces Proof Workflow.
 #
-# Demonstration-fidelity: this script runs the real released
-# workflow-plugin-encrypted-spaces v0.4.0 typed step tests. PASS/FAIL lines are
-# derived from `go test` output, not from hard-coded expected output.
+# Demonstration-fidelity: this executes a Workflow app pipeline with the real
+# workflow-plugin-encrypted-spaces subprocess loaded through wfctl's external
+# plugin path. Storage is an in-memory plugin module, not S3.
 set -uo pipefail
 
-PLUGIN_VERSION="${PLUGIN_VERSION:-v0.4.0}"
-PKG="github.com/GoCodeAlone/workflow-plugin-encrypted-spaces/internal"
-TEST_RE='TestAppendVerifiedAcceptsVectorBackedProof|TestAppendVerifiedRejectsTamperedProof|TestProofEvidenceRedactsPlaintextAndKeyMaterial|TestVectorReportStepFiltersRequiredDomains'
+PLUGIN_NAME="workflow-plugin-encrypted-spaces"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+CONFIG="$SCENARIO_DIR/config/app.yaml"
 
 PASS=0
 FAIL=0
 pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
-
-echo ""
-echo "=== Scenario 105 — Encrypted Spaces Proof Workflow ==="
-echo ""
-
-if ! WORKDIR="$(mktemp -d)"; then
-  fail "could not create temporary module workspace"
+finish() {
   echo ""
   echo "Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ]
+}
+
+find_repo() {
+  local env_value="$1"
+  shift
+  if [ -n "$env_value" ]; then
+    [ -d "$env_value" ] && printf '%s\n' "$env_value" && return 0
+    return 1
+  fi
+  local candidate
+  for candidate in "$@"; do
+    if [ -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_wfctl() {
+  if [ -n "${WFCTL:-}" ]; then
+    [ -x "$WFCTL" ] && printf '%s\n' "$WFCTL" && return 0
+    return 1
+  fi
+
+  local workflow_repo
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  mkdir -p "$workflow_repo/bin" || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/wfctl ./cmd/wfctl) >/dev/null || return 1
+  printf '%s\n' "$workflow_repo/bin/wfctl"
+}
+
+build_plugin() {
+  local plugin_dir="$1"
+  local plugin_repo
+  plugin_repo="$(find_repo "${ENCRYPTED_SPACES_PLUGIN_REPO:-}" "$REPO_ROOT/../workflow-plugin-encrypted-spaces" "$REPO_ROOT/../../../workflow-plugin-encrypted-spaces")" || return 1
+
+  mkdir -p "$plugin_dir/$PLUGIN_NAME" || return 1
+  cp "$plugin_repo/plugin.json" "$plugin_dir/$PLUGIN_NAME/plugin.json" || return 1
+  (cd "$plugin_repo" && GOWORK=off go build \
+    -ldflags "-X github.com/GoCodeAlone/workflow-plugin-encrypted-spaces/internal.Version=${PLUGIN_VERSION:-0.0.0}" \
+    -o "$plugin_dir/$PLUGIN_NAME/$PLUGIN_NAME" ./cmd/workflow-plugin-encrypted-spaces) >/dev/null || return 1
+}
+
+echo ""
+echo "=== Scenario 105 - Encrypted Spaces Proof Workflow ==="
+echo ""
+
+[ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
+
+WFCTL_BIN="$(resolve_wfctl)"
+if [ "$?" -eq 0 ]; then
+  pass "wfctl binary is available"
+else
+  fail "wfctl binary unavailable; set WFCTL or WORKFLOW_REPO"
+  finish
   exit 1
 fi
-trap 'rm -rf "$WORKDIR"' EXIT
 
-(
-  cd "$WORKDIR" || exit 1
-  go mod init scenario-105-encrypted-spaces >/dev/null
-  go get "${PKG}@${PLUGIN_VERSION}" >/dev/null
-)
-if [ "$?" -eq 0 ]; then
-  pass "pinned workflow-plugin-encrypted-spaces ${PLUGIN_VERSION}"
+PLUGIN_DIR="$(mktemp -d)"
+trap 'rm -rf "$PLUGIN_DIR"' EXIT
+
+if build_plugin "$PLUGIN_DIR"; then
+  pass "built workflow-plugin-encrypted-spaces external plugin"
 else
-  fail "could not pin workflow-plugin-encrypted-spaces ${PLUGIN_VERSION}"
+  fail "could not build workflow-plugin-encrypted-spaces; set ENCRYPTED_SPACES_PLUGIN_REPO"
+  finish
+  exit 1
 fi
 
-OUTPUT="$(
-  cd "$WORKDIR" && go test "$PKG" -run "$TEST_RE" -count=1 -v 2>&1
-)"
+OUTPUT="$("$WFCTL_BIN" pipeline run -c "$CONFIG" -p encrypted-space-proof --plugin-dir "$PLUGIN_DIR" --verbose 2>&1)"
 STATUS=$?
 echo "$OUTPUT"
 
 if [ "$STATUS" -eq 0 ]; then
-  pass "released Encrypted Spaces proof workflow tests passed"
+  pass "wfctl pipeline run completed"
 else
-  fail "released Encrypted Spaces proof workflow tests failed"
+  fail "wfctl pipeline run failed"
 fi
 
-echo "$OUTPUT" | grep -q 'TestAppendVerifiedAcceptsVectorBackedProof' \
-  && pass "vector-backed append verification executed" \
-  || fail "vector-backed append verification test did not execute"
+echo "$OUTPUT" | grep -q 'Pipeline completed successfully' \
+  && pass "Workflow engine reported successful pipeline completion" \
+  || fail "Workflow engine did not report successful completion"
 
-echo "$OUTPUT" | grep -q 'TestAppendVerifiedRejectsTamperedProof' \
-  && pass "tamper rejection executed" \
-  || fail "tamper rejection test did not execute"
+echo "$OUTPUT" | grep -q 'append_verified' \
+  && pass "verified append step executed through plugin" \
+  || fail "verified append step was not observed"
 
-echo "$OUTPUT" | grep -q 'TestProofEvidenceRedactsPlaintextAndKeyMaterial' \
-  && pass "proof evidence redaction executed" \
-  || fail "proof evidence redaction test did not execute"
+echo "$OUTPUT" | grep -q 'proof_evidence' \
+  && pass "proof evidence step executed through plugin" \
+  || fail "proof evidence step was not observed"
 
-echo "$OUTPUT" | grep -q 'TestVectorReportStepFiltersRequiredDomains' \
-  && pass "required-domain vector coverage executed" \
-  || fail "required-domain vector coverage test did not execute"
+echo "$OUTPUT" | grep -q 'operationlog.commitment' \
+  && pass "proof report domains flowed through Workflow output" \
+  || fail "proof report domains were not observed"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ] && exit 0 || exit 1
+finish


### PR DESCRIPTION
## Summary
- Replace Signal scenario 104 with a running Workflow server app driven by participant-parametric HTTP client calls.
- Replace Encrypted Spaces scenario 105 with a running Workflow server app driven by space/member/proof API calls and an in-memory store fixture.
- Tighten workflow-scenarios guidance so app scenarios must exercise real app boundaries and avoid hard-coded demo interactions.

## Dependency
- Uses Workflow PR #980 for `step.request_parse` `merge_body` support when typed plugin steps consume HTTP JSON body fields.

## Verification
- `WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/pipeline-external-plugin-tests SIGNAL_PLUGIN_REPO=/Users/jon/workspace/workflow-plugin-signal/.worktrees/signal-plugin-pipeline-tests make test SCENARIO=104-signal-e2e-encryption`
- `WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/pipeline-external-plugin-tests ENCRYPTED_SPACES_PLUGIN_REPO=/Users/jon/workspace/workflow-plugin-encrypted-spaces/.worktrees/encrypted-spaces-pipeline-tests make test SCENARIO=105-encrypted-spaces-proof-workflow`
- `WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/pipeline-external-plugin-tests ./scripts/pre-push`
- `git diff --check`