### PR TITLE
Exercise NoSQL scenario through Workflow app

### DIFF
--- a/scenarios.json
+++ b/scenarios.json
@@ -298,10 +298,10 @@
       "status": "passed",
       "namespace": "wf-scenario-23",
       "deployed": true,
-      "lastTested": "2026-03-28T22:21:48.135584Z",
+      "lastTested": "2026-07-01T15:11:57.695283Z",
       "lastResult": "pass",
-      "testCount": 7,
-      "passCount": 7,
+      "testCount": 15,
+      "passCount": 15,
       "failCount": 0,
       "notes": "NoSQL data store modules (DynamoDB, MongoDB, Redis) with mock backends. CRUD lifecycle via pipeline steps.",
       "blockers": []
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T14:54:36.688040Z"
+  "lastUpdated": "2026-07-01T15:11:57.695283Z"
 }

--- a/scenarios/23-nosql-datastore/config/app.yaml
+++ b/scenarios/23-nosql-datastore/config/app.yaml
@@ -1,128 +1,144 @@
 modules:
-    - name: server
-      type: http.server
-      config:
-        address: ":8080"
-    - name: router
-      type: http.router
-      dependsOn: [server]
-    - name: items
-      type: nosql.memory
-      config:
-        collection: items
+  - name: server
+    type: http.server
+    config:
+      address: ":18123"
+  - name: router
+    type: http.router
+    dependsOn: [server]
+  - name: items
+    type: nosql.memory
+    config:
+      collection: items
 workflows:
-    http:
-        router: router
-        server: server
-        routes: []
+  http:
+    router: router
+    server: server
 pipelines:
-    health:
-        trigger:
-            type: http
-            config:
-                path: /healthz
-                method: GET
-        steps:
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    status: ok
-                    scenario: "23-nosql-datastore"
-    # POST /api/items  — create item by ID
-    create-item:
-        trigger:
-            type: http
-            config:
-                path: /api/items
-                method: POST
-        steps:
-            - name: parse
-              type: step.request_parse
-              config:
-                body: true
-            - name: store
-              type: step.nosql_put
-              config:
-                store: items
-                key: "item:{{.id}}"
-                item: body
-            - name: respond
-              type: step.json_response
-              config:
-                status: 201
-                body:
-                    stored: true
-                    key: "{{.key}}"
-    # GET /api/items/:id  — get item by ID
-    get-item:
-        trigger:
-            type: http
-            config:
-                path: /api/items/:id
-                method: GET
-        steps:
-            - name: validate_id
-              type: step.validate_path_param
-              config:
-                params: [id]
-            - name: fetch
-              type: step.nosql_get
-              config:
-                store: items
-                key: "item:{{.id}}"
-                output: item
-                miss_ok: true
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    found: "{{.found}}"
-                    item: "{{.item}}"
-    # GET /api/items  — list all items (optional prefix filter via ?prefix=)
-    list-items:
-        trigger:
-            type: http
-            config:
-                path: /api/items
-                method: GET
-        steps:
-            - name: query
-              type: step.nosql_query
-              config:
-                store: items
-                prefix: "item:"
-                output: items
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    items: "{{.items}}"
-                    count: "{{.count}}"
-    # DELETE /api/items/:id  — delete item by ID
-    delete-item:
-        trigger:
-            type: http
-            config:
-                path: /api/items/:id
-                method: DELETE
-        steps:
-            - name: validate_id
-              type: step.validate_path_param
-              config:
-                params: [id]
-            - name: remove
-              type: step.nosql_delete
-              config:
-                store: items
-                key: "item:{{.id}}"
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    deleted: true
-                    key: "{{.key}}"
+  health:
+    trigger:
+      type: http
+      config:
+        path: /healthz
+        method: GET
+    steps:
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            status: ok
+            scenario: "23-nosql-datastore"
+
+  create-item:
+    trigger:
+      type: http
+      config:
+        path: /api/items
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          parse_body: true
+          merge_body: true
+      - name: store
+        type: step.nosql_put
+        config:
+          store: items
+          key: "item:{{ .id }}"
+          item: body
+      - name: respond
+        type: step.json_response
+        config:
+          status: 201
+          body:
+            stored: true
+            key: "{{ .key }}"
+            item:
+              _from: body
+
+  get-item:
+    trigger:
+      type: http
+      config:
+        path: /api/items/{id}
+        method: GET
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [id]
+      - name: validate_id
+        type: step.validate_path_param
+        config:
+          params: [id]
+          source: steps.parse.path_params
+      - name: fetch
+        type: step.nosql_get
+        config:
+          store: items
+          key: 'item:{{ index .steps "parse" "path_params" "id" }}'
+          output: item
+          miss_ok: true
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            found:
+              _from: found
+            item:
+              _from: item
+
+  list-items:
+    trigger:
+      type: http
+      config:
+        path: /api/items
+        method: GET
+    steps:
+      - name: query
+        type: step.nosql_query
+        config:
+          store: items
+          prefix: "item:"
+          output: items
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            items:
+              _from: items
+            count:
+              _from: count
+
+  delete-item:
+    trigger:
+      type: http
+      config:
+        path: /api/items/{id}
+        method: DELETE
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [id]
+      - name: validate_id
+        type: step.validate_path_param
+        config:
+          params: [id]
+          source: steps.parse.path_params
+      - name: remove
+        type: step.nosql_delete
+        config:
+          store: items
+          key: 'item:{{ index .steps "parse" "path_params" "id" }}'
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            deleted: true
+            key: "{{ .key }}"

--- a/scenarios/23-nosql-datastore/test/run.sh
+++ b/scenarios/23-nosql-datastore/test/run.sh
@@ -1,39 +1,173 @@
 #!/usr/bin/env bash
-# Scenario 23: NoSQL Data Store
-# Tests the NoSQL module pipeline steps (get, put, delete, query) using the
-# in-memory backend. Runs go unit tests from the workflow repo.
-set -euo pipefail
+# Scenario 23: NoSQL Data Store.
+#
+# Demonstration-fidelity: this starts the real Workflow server from the
+# scenario config and drives the in-memory NoSQL module through HTTP API calls.
+set -uo pipefail
 
-WORKFLOW_REPO="${WORKFLOW_REPO:-$(cd "$(dirname "$0")/../../.." && pwd)/../workflow}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:18123}"
+ITEM_ID="${ITEM_ID:-item-23-a}"
+ITEM_NAME="${ITEM_NAME:-Workflow scenario item}"
+ITEM_KIND="${ITEM_KIND:-scenario-proof}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+CONFIG="$SCENARIO_DIR/config/app.yaml"
+
 PASS=0
 FAIL=0
+SERVER_PID=""
+DATA_DIR=""
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+finish() {
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ]
+}
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  [ -n "$DATA_DIR" ] && rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
 
-pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
-fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+find_repo() {
+  local env_value="$1"
+  shift
+  if [ -n "$env_value" ]; then
+    [ -d "$env_value" ] && printf '%s\n' "$env_value" && return 0
+    return 1
+  fi
+  local candidate
+  for candidate in "$@"; do
+    if [ -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_server() {
+  if [ -n "${WORKFLOW_SERVER:-}" ]; then
+    [ -x "$WORKFLOW_SERVER" ] && printf '%s\n' "$WORKFLOW_SERVER" && return 0
+    return 1
+  fi
+
+  local workflow_repo
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-${WORKFLOW_DIR:-}}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  mkdir -p "$workflow_repo/bin" || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/workflow-server ./cmd/server) >/dev/null 2>&1 || return 1
+  printf '%s\n' "$workflow_repo/bin/workflow-server"
+}
+
+wait_for_server() {
+  local url="$1"
+  local i
+  for i in $(seq 1 80); do
+    curl -fs "$url/healthz" >/dev/null 2>&1 && return 0
+    if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 0.25
+  done
+  return 1
+}
 
 echo ""
-echo "=== Scenario 23: NoSQL Data Store (unit tests) ==="
+echo "=== Scenario 23: NoSQL Data Store ==="
 echo ""
 
-if [ ! -d "$WORKFLOW_REPO" ]; then
-    fail "workflow repo not found at $WORKFLOW_REPO"
-    echo "Results: $PASS passed, $FAIL failed"
-    exit 1
+[ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
+if sed '/^[[:space:]]*#/d' "$SCRIPT_DIR/run.sh" | grep -Eq '(^|[;&|[:space:]])go[[:space:]]+test'; then
+  fail "scenario test should not delegate proof to Go package tests"
+else
+  pass "scenario test exercises the Workflow app boundary"
+fi
+if grep -Eq 'item-23-a|Workflow scenario item' "$CONFIG"; then
+  fail "Workflow config should not hard-code the test item"
+else
+  pass "Workflow API accepts item data from client requests"
 fi
 
-# Run go tests and parse output
-while IFS= read -r line; do
-    if [[ "$line" =~ ^"--- PASS: "(.*)" " ]] || [[ "$line" =~ ^"--- PASS: "(.*)$ ]]; then
-        name="${line#--- PASS: }"
-        name="${name%% (*}"
-        pass "$name"
-    elif [[ "$line" =~ ^"--- FAIL: " ]]; then
-        name="${line#--- FAIL: }"
-        name="${name%% (*}"
-        fail "$name"
-    fi
-done < <(cd "$WORKFLOW_REPO" && go test ./module/ -v -count=1 -run "TestNoSQL" 2>&1)
+SERVER_BIN="$(resolve_server)"
+if [ "$?" -eq 0 ]; then
+  pass "workflow server binary is available"
+else
+  fail "workflow server unavailable; set WORKFLOW_SERVER or WORKFLOW_REPO"
+  finish
+  exit 1
+fi
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ]
+if ! DATA_DIR="$(mktemp -d)"; then
+  fail "could not create temporary data directory"
+  finish
+  exit 1
+fi
+
+SERVER_LOG="$SCRIPT_DIR/artifacts/last-server.log"
+mkdir -p "$(dirname "$SERVER_LOG")"
+"$SERVER_BIN" -config "$CONFIG" -data-dir "$DATA_DIR" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+if wait_for_server "$BASE_URL"; then
+  pass "workflow server started and served /healthz"
+else
+  fail "workflow server did not become ready; see $SERVER_LOG"
+  finish
+  exit 1
+fi
+
+CREATE_BODY="$(jq -cn --arg id "$ITEM_ID" --arg name "$ITEM_NAME" --arg kind "$ITEM_KIND" \
+  '{id:$id,name:$name,kind:$kind,active:true,revision:1}')" || CREATE_BODY=""
+CREATED="$(curl -fsS -X POST "$BASE_URL/api/items" -H 'Content-Type: application/json' -d "$CREATE_BODY")" \
+  && pass "client created an item through Workflow API" \
+  || fail "create item API failed"
+
+if printf '%s' "$CREATED" | jq -e --arg key "item:$ITEM_ID" '.stored == true and .key == $key and .item.id == ($key | sub("^item:"; ""))' >/dev/null 2>&1; then
+  pass "create response contained stored item key and body"
+else
+  fail "create response did not contain expected item: $CREATED"
+fi
+
+LISTED="$(curl -fsS "$BASE_URL/api/items")" \
+  && pass "client listed items through Workflow API" \
+  || fail "list items API failed"
+if printf '%s' "$LISTED" | jq -e --arg id "$ITEM_ID" '.count == 1 and (.items[] | select(.id == $id))' >/dev/null 2>&1; then
+  pass "list response contained the created item"
+else
+  fail "list response missing created item: $LISTED"
+fi
+
+FETCHED="$(curl -fsS "$BASE_URL/api/items/$ITEM_ID")" \
+  && pass "client fetched item by ID through Workflow API" \
+  || fail "get item API failed"
+if printf '%s' "$FETCHED" | jq -e --arg id "$ITEM_ID" --arg name "$ITEM_NAME" '.found == true and .item.id == $id and .item.name == $name' >/dev/null 2>&1; then
+  pass "get response returned the stored item"
+else
+  fail "get response mismatch: $FETCHED"
+fi
+
+DELETED="$(curl -fsS -X DELETE "$BASE_URL/api/items/$ITEM_ID")" \
+  && pass "client deleted item by ID through Workflow API" \
+  || fail "delete item API failed"
+if printf '%s' "$DELETED" | jq -e --arg key "item:$ITEM_ID" '.deleted == true and .key == $key' >/dev/null 2>&1; then
+  pass "delete response contained deleted item key"
+else
+  fail "delete response mismatch: $DELETED"
+fi
+
+MISSING="$(curl -fsS "$BASE_URL/api/items/$ITEM_ID")" \
+  && pass "client re-fetched deleted item through Workflow API" \
+  || fail "get deleted item API failed"
+if printf '%s' "$MISSING" | jq -e '.found == false and (.item | type == "object") and (.item | length == 0)' >/dev/null 2>&1; then
+  pass "deleted item is no longer present"
+else
+  fail "deleted item still appears present: $MISSING"
+fi
+
+finish


### PR DESCRIPTION
## Summary
- convert scenario 23 from parsing `go test` output to launching the real Workflow server
- drive create/list/get/delete through HTTP routes backed by `nosql.memory` and NoSQL pipeline steps
- keep item IDs and payloads client-provided instead of hard-coded in the Workflow config

## Validation
- `WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/pipeline-external-plugin-tests make test SCENARIO=23-nosql-datastore` -> 15/15 passed
- `jq empty scenarios.json`
- `git diff --check origin/main...HEAD`

## Notes
- This is the first package-test-only scenario conversion from `docs/backlog/scenario-proof-quality.md`.
