### PR TITLE
Exercise artifact scenario through Workflow app

### DIFF
--- a/scenarios.json
+++ b/scenarios.json
@@ -310,10 +310,10 @@
       "status": "passed",
       "namespace": "wf-scenario-24",
       "deployed": true,
-      "lastTested": "2026-03-28T22:21:52.852340Z",
+      "lastTested": "2026-07-01T15:51:02.537835Z",
       "lastResult": "pass",
-      "testCount": 22,
-      "passCount": 22,
+      "testCount": 15,
+      "passCount": 15,
       "failCount": 0,
       "notes": "Artifact store with filesystem backend. Upload, download, list, delete lifecycle via pipeline steps.",
       "blockers": []
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T15:11:57.695283Z"
+  "lastUpdated": "2026-07-01T15:51:02.537835Z"
 }

--- a/scenarios/24-artifact-store/config/app.yaml
+++ b/scenarios/24-artifact-store/config/app.yaml
@@ -1,229 +1,150 @@
-# ============================================================
-# Scenario 24 — Artifact Store
-#
-# Demonstrates the storage.artifact module (filesystem backend)
-# and the artifact upload/download/list/delete pipeline steps.
-#
-# Endpoints:
-#   POST   /api/v1/artifacts/upload  — upload artifact
-#   GET    /api/v1/artifacts/get     — download artifact (?key=...)
-#   GET    /api/v1/artifacts         — list artifacts    (?prefix=...)
-#   DELETE /api/v1/artifacts/delete  — delete artifact   (?key=...)
-#   GET    /healthz                  — health check
-# ============================================================
-
 modules:
-    - name: server
-      type: http.server
-      config:
-        address: ":8080"
-    - name: router
-      type: http.router
-      dependsOn: [server]
-    - name: artifacts
-      type: storage.artifact
-      config:
-        backend: filesystem
-        basePath: /data/artifacts
-      dependsOn: []
+  - name: server
+    type: http.server
+    config:
+      address: ":18124"
+  - name: router
+    type: http.router
+    dependsOn: [server]
+  - name: artifacts
+    type: storage.artifact
+    config:
+      backend: filesystem
+      basePath: artifacts
 workflows:
-    http:
-        router: router
-        server: server
-        routes: []
+  http:
+    router: router
+    server: server
 pipelines:
-    # ----------------------------------------------------------------
-    # Health check
-    # ----------------------------------------------------------------
-    health:
-        trigger:
-            type: http
-            config:
-                path: /healthz
-                method: GET
-        steps:
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    status: ok
-                    scenario: "24-artifact-store"
-    # ----------------------------------------------------------------
-    # Upload — POST /api/v1/artifacts/upload
-    #
-    # Accepts JSON body: { "key": "builds/v1/app.bin", "content": "<base64>", "metadata": {} }
-    # Writes content to a temp file then uploads via step.artifact_upload.
-    # ----------------------------------------------------------------
-    artifact-upload:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/artifacts/upload
-                method: POST
-        steps:
-            - name: parse
-              type: step.request_parse
-              config:
-                fields:
-                    - name: key
-                      source: body
-                      path: key
-                      required: true
-                    - name: content
-                      source: body
-                      path: content
-                      required: true
-                    - name: content_type
-                      source: body
-                      path: content_type
-                      default: "application/octet-stream"
-                    - name: version
-                      source: body
-                      path: metadata.version
-                      default: ""
-                    - name: commit
-                      source: body
-                      path: metadata.commit
-                      default: ""
-            - name: decode_and_store
-              type: step.shell_exec
-              config:
-                image: alpine:3.21
-                commands:
-                    - |
-                      KEY="{{ .key }}"
-                      CONTENT="{{ .content }}"
-                      TMPDIR="/tmp/wf-artifact-$$"
-                      mkdir -p "$TMPDIR"
-                      TMPFILE="$TMPDIR/artifact"
-                      echo "$CONTENT" | base64 -d > "$TMPFILE"
-                      echo "{\"tmpfile\":\"$TMPFILE\",\"size\":$(wc -c < "$TMPFILE")}"
-                output_field: shell_result
-                parse_json: true
-            - name: upload
-              type: step.artifact_upload
-              config:
-                store: artifacts
-                key: "{{ .key }}"
-                source: "{{ .shell_result.tmpfile }}"
-                metadata:
-                    version: "{{ .version }}"
-                    commit: "{{ .commit }}"
-                    content_type: "{{ .content_type }}"
-            - name: respond
-              type: step.json_response
-              config:
-                status: 201
-                body:
-                    status: uploaded
-                    key: "{{ .key }}"
-                    size: "{{ .shell_result.size }}"
-    # ----------------------------------------------------------------
-    # Download — GET /api/v1/artifacts/get?key=<path>
-    # ----------------------------------------------------------------
-    artifact-download:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/artifacts/get
-                method: GET
-        steps:
-            - name: parse
-              type: step.request_parse
-              config:
-                fields:
-                    - name: key
-                      source: query
-                      path: key
-                      required: true
-            - name: check_exists
-              type: step.shell_exec
-              config:
-                image: alpine:3.21
-                commands:
-                    - |
-                      KEY="{{ .key }}"
-                      SAFE_KEY=$(echo "$KEY" | sed 's|[^a-zA-Z0-9/_.-]||g')
-                      FILE="/data/artifacts/$SAFE_KEY"
-                      if [ -f "$FILE" ]; then
-                        SIZE=$(wc -c < "$FILE")
-                        CONTENT=$(base64 < "$FILE")
-                        echo "{\"exists\":true,\"size\":$SIZE,\"content\":\"$CONTENT\"}"
-                      else
-                        echo "{\"exists\":false}"
-                      fi
-                output_field: artifact_data
-                parse_json: true
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    status: ok
-                    key: "{{ .key }}"
-                    exists: "{{ .artifact_data.exists }}"
-                    size: "{{ .artifact_data.size }}"
-                    content: "{{ .artifact_data.content }}"
-    # ----------------------------------------------------------------
-    # List — GET /api/v1/artifacts?prefix=<prefix>
-    # ----------------------------------------------------------------
-    artifact-list:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/artifacts
-                method: GET
-        steps:
-            - name: parse
-              type: step.request_parse
-              config:
-                fields:
-                    - name: prefix
-                      source: query
-                      path: prefix
-                      default: ""
-            - name: list
-              type: step.artifact_list
-              config:
-                store: artifacts
-                prefix: "{{ .prefix }}"
-                output: artifacts
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    status: ok
-                    count: "{{ .count }}"
-                    artifacts: "{{ .artifacts }}"
-    # ----------------------------------------------------------------
-    # Delete — DELETE /api/v1/artifacts/delete?key=<path>
-    # ----------------------------------------------------------------
-    artifact-delete:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/artifacts/delete
-                method: DELETE
-        steps:
-            - name: parse
-              type: step.request_parse
-              config:
-                fields:
-                    - name: key
-                      source: query
-                      path: key
-                      required: true
-            - name: delete
-              type: step.artifact_delete
-              config:
-                store: artifacts
-                key: "{{ .key }}"
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    status: deleted
-                    key: "{{ .key }}"
+  health:
+    trigger:
+      type: http
+      config:
+        path: /healthz
+        method: GET
+    steps:
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            status: ok
+            scenario: "24-artifact-store"
+
+  upload-artifact:
+    trigger:
+      type: http
+      config:
+        path: /api/artifacts
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          parse_body: true
+          merge_body: true
+      - name: upload
+        type: step.artifact_upload
+        config:
+          store: artifacts
+          key: "{{ .key }}"
+          content_from: content_b64
+          content_encoding: base64
+          metadata:
+            owner: "{{ .owner }}"
+            version: "{{ .version }}"
+            content_type: "{{ .content_type }}"
+      - name: respond
+        type: step.json_response
+        config:
+          status: 201
+          body:
+            uploaded: true
+            key: "{{ .key }}"
+            size:
+              _from: size
+
+  download-artifact:
+    trigger:
+      type: http
+      config:
+        path: /api/artifacts/download
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          parse_body: true
+          merge_body: true
+      - name: download
+        type: step.artifact_download
+        config:
+          store: artifacts
+          key: "{{ .key }}"
+          content_encoding: base64
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            key: "{{ .key }}"
+            content_b64:
+              _from: artifact_content
+            size:
+              _from: size
+            metadata:
+              _from: metadata
+
+  list-artifacts:
+    trigger:
+      type: http
+      config:
+        path: /api/artifacts/list
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          parse_body: true
+          merge_body: true
+      - name: list
+        type: step.artifact_list
+        config:
+          store: artifacts
+          prefix: "{{ .prefix }}"
+          output: artifacts
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            count:
+              _from: count
+            artifacts:
+              _from: artifacts
+
+  delete-artifact:
+    trigger:
+      type: http
+      config:
+        path: /api/artifacts/delete
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          parse_body: true
+          merge_body: true
+      - name: delete
+        type: step.artifact_delete
+        config:
+          store: artifacts
+          key: "{{ .key }}"
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            deleted:
+              _from: deleted
+            key: "{{ .key }}"

--- a/scenarios/24-artifact-store/scenario.yaml
+++ b/scenarios/24-artifact-store/scenario.yaml
@@ -7,16 +7,15 @@ description: |
   step.artifact_delete pipeline steps.
 
   Endpoints:
-    POST   /api/v1/artifacts/upload        — upload artifact (multipart or JSON+base64)
-    GET    /api/v1/artifacts/{key}         — download artifact (key in query param)
-    GET    /api/v1/artifacts               — list artifacts (optional ?prefix=)
-    DELETE /api/v1/artifacts/{key}         — delete artifact (key in query param)
+    POST   /api/artifacts                  — upload artifact JSON+base64
+    POST   /api/artifacts/download         — download artifact JSON+base64
+    POST   /api/artifacts/list             — list artifacts by prefix
+    POST   /api/artifacts/delete           — delete artifact by key
     GET    /healthz                        — health check
 
 components:
   - workflow (engine)
   - storage.artifact module (filesystem backend)
-  - PVC for artifact data
 
 tags:
   - cicd
@@ -26,6 +25,6 @@ tags:
 
 status: pending
 notes: |
-  Port-forward uses 18024.
-  Artifacts stored at /data/artifacts inside the container (PVC-mounted).
-  Key is passed as query param ?key=<path> due to pipeline path-param constraints.
+  Local app proof uses port 18124.
+  Artifacts are stored under a temp server working directory during the test.
+  The runner supplies caller-selected artifact keys, content, owner, and version.

--- a/scenarios/24-artifact-store/test/run.sh
+++ b/scenarios/24-artifact-store/test/run.sh
@@ -1,38 +1,191 @@
 #!/usr/bin/env bash
-# Scenario 24: Artifact Store
-# Tests the artifact store module: upload, download, list, delete, and edge cases.
-# Runs go unit tests from the workflow repo.
-set -euo pipefail
+# Scenario 24: Artifact Store.
+#
+# Demonstration-fidelity: this starts the real Workflow server from the
+# scenario config and drives storage.artifact through HTTP API calls.
+set -uo pipefail
 
-WORKFLOW_REPO="${WORKFLOW_REPO:-$(cd "$(dirname "$0")/../../.." && pwd)/../workflow}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:18124}"
+ARTIFACT_OWNER="${ARTIFACT_OWNER:-client-a}"
+ARTIFACT_VERSION="${ARTIFACT_VERSION:-v1}"
+ARTIFACT_PREFIX="${ARTIFACT_PREFIX:-builds/scenario-24}"
+ARTIFACT_ID="${ARTIFACT_ID:-artifact-$(date +%s)}"
+ARTIFACT_KEY="${ARTIFACT_KEY:-$ARTIFACT_PREFIX/$ARTIFACT_ID/app.bin}"
+ARTIFACT_TEXT="${ARTIFACT_TEXT:-Workflow artifact scenario payload from $ARTIFACT_OWNER}"
+ARTIFACT_TYPE="${ARTIFACT_TYPE:-application/octet-stream}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+CONFIG="$SCENARIO_DIR/config/app.yaml"
+
 PASS=0
 FAIL=0
+SERVER_PID=""
+DATA_DIR=""
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+finish() {
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ]
+}
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  [ -n "$DATA_DIR" ] && rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
 
-pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
-fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+find_repo() {
+  local env_value="$1"
+  shift
+  if [ -n "$env_value" ]; then
+    [ -d "$env_value" ] && printf '%s\n' "$env_value" && return 0
+    return 1
+  fi
+  local candidate
+  for candidate in "$@"; do
+    if [ -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_server() {
+  if [ -n "${WORKFLOW_SERVER:-}" ]; then
+    [ -x "$WORKFLOW_SERVER" ] && printf '%s\n' "$WORKFLOW_SERVER" && return 0
+    return 1
+  fi
+
+  local workflow_repo
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-${WORKFLOW_DIR:-}}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  mkdir -p "$workflow_repo/bin" || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/workflow-server ./cmd/server) >/dev/null 2>&1 || return 1
+  printf '%s\n' "$workflow_repo/bin/workflow-server"
+}
+
+wait_for_server() {
+  local url="$1"
+  local i
+  for i in $(seq 1 80); do
+    curl -fs "$url/healthz" >/dev/null 2>&1 && return 0
+    if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 0.25
+  done
+  return 1
+}
 
 echo ""
-echo "=== Scenario 24: Artifact Store (unit tests) ==="
+echo "=== Scenario 24: Artifact Store ==="
 echo ""
 
-if [ ! -d "$WORKFLOW_REPO" ]; then
-    fail "workflow repo not found at $WORKFLOW_REPO"
-    echo "Results: $PASS passed, $FAIL failed"
-    exit 1
+[ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
+if sed '/^[[:space:]]*#/d' "$SCRIPT_DIR/run.sh" | grep -Eq '(^|[;&|[:space:]])go[[:space:]]+test'; then
+  fail "scenario test should not delegate proof to Go package tests"
+else
+  pass "scenario test exercises the Workflow app boundary"
+fi
+if grep -Eq 'artifact-[0-9]+|Workflow artifact scenario payload|client-a' "$CONFIG"; then
+  fail "Workflow config should not hard-code the test artifact"
+else
+  pass "Workflow API accepts artifact identity and content from client requests"
 fi
 
-while IFS= read -r line; do
-    if [[ "$line" =~ ^"--- PASS: " ]]; then
-        name="${line#--- PASS: }"
-        name="${name%% (*}"
-        pass "$name"
-    elif [[ "$line" =~ ^"--- FAIL: " ]]; then
-        name="${line#--- FAIL: }"
-        name="${name%% (*}"
-        fail "$name"
-    fi
-done < <(cd "$WORKFLOW_REPO" && go test ./module/ -v -count=1 -run "TestArtifact" 2>&1)
+SERVER_BIN="$(resolve_server)"
+if [ "$?" -eq 0 ]; then
+  pass "workflow server binary is available"
+else
+  fail "workflow server unavailable; set WORKFLOW_SERVER or WORKFLOW_REPO"
+  finish
+  exit 1
+fi
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ]
+if ! DATA_DIR="$(mktemp -d)"; then
+  fail "could not create temporary data directory"
+  finish
+  exit 1
+fi
+
+SERVER_LOG="$SCRIPT_DIR/artifacts/last-server.log"
+mkdir -p "$(dirname "$SERVER_LOG")"
+(cd "$DATA_DIR" && "$SERVER_BIN" -config "$CONFIG" -data-dir "$DATA_DIR" >"$SERVER_LOG" 2>&1) &
+SERVER_PID=$!
+
+if wait_for_server "$BASE_URL"; then
+  pass "workflow server started and served /healthz"
+else
+  fail "workflow server did not become ready; see $SERVER_LOG"
+  finish
+  exit 1
+fi
+
+CONTENT_B64="$(printf '%s' "$ARTIFACT_TEXT" | base64 | tr -d '\n')"
+UPLOAD_BODY="$(jq -cn \
+  --arg key "$ARTIFACT_KEY" \
+  --arg content_b64 "$CONTENT_B64" \
+  --arg owner "$ARTIFACT_OWNER" \
+  --arg version "$ARTIFACT_VERSION" \
+  --arg content_type "$ARTIFACT_TYPE" \
+  '{key:$key,content_b64:$content_b64,owner:$owner,version:$version,content_type:$content_type}')" || UPLOAD_BODY=""
+
+UPLOADED="$(curl -fsS -X POST "$BASE_URL/api/artifacts" -H 'Content-Type: application/json' -d "$UPLOAD_BODY")" \
+  && pass "client uploaded artifact content through Workflow API" \
+  || fail "upload artifact API failed"
+if printf '%s' "$UPLOADED" | jq -e --arg key "$ARTIFACT_KEY" --argjson size "${#ARTIFACT_TEXT}" \
+  '.uploaded == true and .key == $key and .size == $size' >/dev/null 2>&1; then
+  pass "upload response contained artifact key and byte size"
+else
+  fail "upload response mismatch: $UPLOADED"
+fi
+
+LIST_BODY="$(jq -cn --arg prefix "$ARTIFACT_PREFIX" '{prefix:$prefix}')"
+LISTED="$(curl -fsS -X POST "$BASE_URL/api/artifacts/list" -H 'Content-Type: application/json' -d "$LIST_BODY")" \
+  && pass "client listed artifacts by prefix through Workflow API" \
+  || fail "list artifacts API failed"
+if printf '%s' "$LISTED" | jq -e --arg key "$ARTIFACT_KEY" --arg owner "$ARTIFACT_OWNER" \
+  '.count == 1 and (.artifacts[] | select(.key == $key and .metadata.owner == $owner))' >/dev/null 2>&1; then
+  pass "list response contained uploaded artifact metadata"
+else
+  fail "list response missing uploaded artifact: $LISTED"
+fi
+
+KEY_BODY="$(jq -cn --arg key "$ARTIFACT_KEY" '{key:$key}')"
+DOWNLOADED="$(curl -fsS -X POST "$BASE_URL/api/artifacts/download" -H 'Content-Type: application/json' -d "$KEY_BODY")" \
+  && pass "client downloaded artifact content through Workflow API" \
+  || fail "download artifact API failed"
+if printf '%s' "$DOWNLOADED" | jq -e \
+  --arg key "$ARTIFACT_KEY" \
+  --arg content_b64 "$CONTENT_B64" \
+  --arg owner "$ARTIFACT_OWNER" \
+  '.key == $key and .content_b64 == $content_b64 and .metadata.owner == $owner' >/dev/null 2>&1; then
+  pass "download response returned original content and metadata"
+else
+  fail "download response mismatch: $DOWNLOADED"
+fi
+
+DELETED="$(curl -fsS -X POST "$BASE_URL/api/artifacts/delete" -H 'Content-Type: application/json' -d "$KEY_BODY")" \
+  && pass "client deleted artifact through Workflow API" \
+  || fail "delete artifact API failed"
+if printf '%s' "$DELETED" | jq -e --arg key "$ARTIFACT_KEY" '.deleted == true and .key == $key' >/dev/null 2>&1; then
+  pass "delete response contained deleted artifact key"
+else
+  fail "delete response mismatch: $DELETED"
+fi
+
+LISTED_AFTER_DELETE="$(curl -fsS -X POST "$BASE_URL/api/artifacts/list" -H 'Content-Type: application/json' -d "$LIST_BODY")" \
+  && pass "client listed artifacts after delete through Workflow API" \
+  || fail "list after delete API failed"
+if printf '%s' "$LISTED_AFTER_DELETE" | jq -e '.count == 0 and (.artifacts | length == 0)' >/dev/null 2>&1; then
+  pass "deleted artifact is no longer listed"
+else
+  fail "deleted artifact still appears present: $LISTED_AFTER_DELETE"
+fi
+
+finish


### PR DESCRIPTION
## Summary
- replace scenario 24 package-test proxy with a real Workflow HTTP app proof
- drive artifact upload/list/download/delete through storage.artifact and artifact pipeline steps
- keep caller-selected artifact identity/content in the runner instead of hard-coded pipeline data

## Verification
- WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/artifact-content-steps make test SCENARIO=24-artifact-store (15/15 passed)
- git diff --check HEAD