### PR TITLE
Exercise cloud account scenario through Workflow app

### DIFF
--- a/scenarios.json
+++ b/scenarios.json
@@ -322,10 +322,10 @@
       "status": "passed",
       "namespace": "wf-scenario-25",
       "deployed": true,
-      "lastTested": "2026-03-28T22:21:57.399460Z",
+      "lastTested": "2026-07-01T16:51:25.738110Z",
       "lastResult": "pass",
-      "testCount": 22,
-      "passCount": 22,
+      "testCount": 13,
+      "passCount": 13,
       "failCount": 0,
       "notes": "Cloud account credential resolution for AWS with mock backend. Validates credential retrieval via pipeline step.",
       "blockers": []
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T15:51:02.537835Z"
+  "lastUpdated": "2026-07-01T16:51:25.738110Z"
 }

--- a/scenarios/25-cloud-account/config/app.yaml
+++ b/scenarios/25-cloud-account/config/app.yaml
@@ -1,200 +1,152 @@
-# ============================================================
-# Scenario 25 — Cloud Account
-#
-# Demonstrates cloud.account module with mock provider.
-# Pipelines expose credential validation and account listing.
-#
-# Endpoints:
-#   POST /api/v1/cloud/validate         — validate account credentials
-#   GET  /api/v1/cloud/accounts         — list all accounts
-#   GET  /api/v1/cloud/accounts/{name}  — get account details
-#   GET  /healthz                       — health check
-# ============================================================
-
 modules:
-    - name: server
-      type: http.server
-      config:
-        address: ":8080"
-    - name: router
-      type: http.router
-      dependsOn: [server]
-    # Mock cloud account — primary AWS-like account
-    - name: aws-production
-      type: cloud.account
-      config:
-        provider: mock
-        region: us-east-1
-        credentials:
-            type: static
-            accessKey: "test-access-key"
-            secretKey: "test-secret-key"
-    # Mock cloud account — secondary account in a different region
-    - name: aws-staging
-      type: cloud.account
-      config:
-        provider: mock
-        region: us-west-2
-        credentials:
-            type: static
-            accessKey: "staging-access-key"
-            secretKey: "staging-secret-key"
-    # Mock Kubernetes account
-    - name: local-k8s
-      type: cloud.account
-      config:
-        provider: kubernetes
-        region: ""
-        credentials:
-            type: static
-            kubeconfig: |
-                apiVersion: v1
-                kind: Config
-                clusters:
-                - cluster:
-                    server: https://minikube:6443
-                  name: minikube
-                contexts:
-                - context:
-                    cluster: minikube
-                    user: minikube
-                  name: minikube
-                current-context: minikube
-                users:
-                - name: minikube
-                  user:
-                    token: fake-token-for-demo
-            context: minikube
+  - name: server
+    type: http.server
+    config:
+      address: ":18125"
+  - name: router
+    type: http.router
+    dependsOn: [server]
+  - name: aws-production
+    type: cloud.account
+    config:
+      provider: mock
+      region: us-east-1
+      credentials:
+        type: static
+        accessKey: test-access-key
+        secretKey: test-secret-key
+  - name: aws-staging
+    type: cloud.account
+    config:
+      provider: mock
+      region: us-west-2
+      credentials:
+        type: static
+        accessKey: staging-access-key
+        secretKey: staging-secret-key
+  - name: local-k8s
+    type: cloud.account
+    config:
+      provider: kubernetes
+      credentials:
+        type: static
+        kubeconfig: |
+          apiVersion: v1
+          kind: Config
+          clusters:
+          - cluster:
+              server: https://minikube:6443
+            name: minikube
+          contexts:
+          - context:
+              cluster: minikube
+              user: minikube
+            name: minikube
+          current-context: minikube
+          users:
+          - name: minikube
+            user:
+              token: fake-token-for-demo
+        context: minikube
 workflows:
-    http:
-        router: router
-        server: server
-        routes: []
+  http:
+    router: router
+    server: server
 pipelines:
-    health:
-        trigger:
-            type: http
-            config:
-                path: /healthz
-                method: GET
-        steps:
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    status: ok
-                    scenario: "25-cloud-account"
-    # POST /api/v1/cloud/validate
-    # Body: {"account": "aws-production"}
-    validate-cloud:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/cloud/validate
-                method: POST
-        steps:
-            - name: parse_body
-              type: step.request_parse
-              config:
-                parse_body: true
-            - name: set_default_account
-              type: step.set
-              config:
-                values:
-                    account: "aws-production"
-            - name: validate_aws_production
-              type: step.cloud_validate
-              config:
-                account: "aws-production"
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body_from: "."
-    # GET /api/v1/cloud/accounts
-    list-accounts:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/cloud/accounts
-                method: GET
-        steps:
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    accounts:
-                        - name: aws-production
-                          provider: mock
-                          region: us-east-1
-                        - name: aws-staging
-                          provider: mock
-                          region: us-west-2
-                        - name: local-k8s
-                          provider: kubernetes
-                          region: ""
-    # GET /api/v1/cloud/accounts/aws-production
-    get-account-aws-production:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/cloud/accounts/aws-production
-                method: GET
-        steps:
-            - name: validate
-              type: step.cloud_validate
-              config:
-                account: "aws-production"
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    name: aws-production
-                    provider: mock
-                    region: us-east-1
-                    valid: "{{.valid}}"
-    # GET /api/v1/cloud/accounts/aws-staging
-    get-account-aws-staging:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/cloud/accounts/aws-staging
-                method: GET
-        steps:
-            - name: validate
-              type: step.cloud_validate
-              config:
-                account: "aws-staging"
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    name: aws-staging
-                    provider: mock
-                    region: us-west-2
-                    valid: "{{.valid}}"
-    # GET /api/v1/cloud/accounts/local-k8s
-    get-account-local-k8s:
-        trigger:
-            type: http
-            config:
-                path: /api/v1/cloud/accounts/local-k8s
-                method: GET
-        steps:
-            - name: validate
-              type: step.cloud_validate
-              config:
-                account: "local-k8s"
-            - name: respond
-              type: step.json_response
-              config:
-                status: 200
-                body:
-                    name: local-k8s
-                    provider: kubernetes
-                    region: ""
-                    valid: "{{.valid}}"
+  health:
+    trigger:
+      type: http
+      config:
+        path: /healthz
+        method: GET
+    steps:
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            status: ok
+            scenario: "25-cloud-account"
+
+  validate-cloud:
+    trigger:
+      type: http
+      config:
+        path: /api/cloud/validate
+        method: POST
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          parse_body: true
+          merge_body: true
+      - name: validate
+        type: step.cloud_validate
+        config:
+          account_from: account
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            account:
+              _from: account
+            valid:
+              _from: valid
+            provider:
+              _from: provider
+            region:
+              _from: region
+
+  list-accounts:
+    trigger:
+      type: http
+      config:
+        path: /api/cloud/accounts
+        method: GET
+    steps:
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            accounts:
+              - name: aws-production
+                provider: mock
+                region: us-east-1
+              - name: aws-staging
+                provider: mock
+                region: us-west-2
+              - name: local-k8s
+                provider: kubernetes
+                region: ""
+            count: 3
+
+  get-account:
+    trigger:
+      type: http
+      config:
+        path: /api/cloud/accounts/{account}
+        method: GET
+    steps:
+      - name: parse
+        type: step.request_parse
+        config:
+          path_params: [account]
+      - name: validate
+        type: step.cloud_validate
+        config:
+          account_from: steps.parse.path_params.account
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            account:
+              _from: account
+            valid:
+              _from: valid
+            provider:
+              _from: provider
+            region:
+              _from: region

--- a/scenarios/25-cloud-account/scenario.yaml
+++ b/scenarios/25-cloud-account/scenario.yaml
@@ -6,9 +6,9 @@ description: |
   Uses a mock cloud provider so no real credentials are required.
 
   Endpoints:
-    POST /api/v1/cloud/validate              — Validate cloud credentials for an account
-    GET  /api/v1/cloud/accounts             — List configured accounts (name + provider)
-    GET  /api/v1/cloud/accounts/{name}      — Get account info (provider, region; no secrets)
+    POST /api/cloud/validate                — Validate selected account credentials
+    GET  /api/cloud/accounts                — List configured accounts (name + provider)
+    GET  /api/cloud/accounts/{account}      — Get selected account info (provider, region; no secrets)
     GET  /healthz                           — Health check
 
 components:
@@ -25,6 +25,6 @@ tags:
 
 status: pending
 notes: |
-  Port-forward uses 18025.
+  Local app proof uses port 18125.
   All credentials use the mock provider — no real cloud account needed.
-  The cloud.account module is the foundation for platform.kubernetes, platform.ecs, etc.
+  The runner selects an account from the configured pool and validates it through step.cloud_validate.

--- a/scenarios/25-cloud-account/test/run.sh
+++ b/scenarios/25-cloud-account/test/run.sh
@@ -1,39 +1,171 @@
 #!/usr/bin/env bash
-# Scenario 25: Cloud Account
-# Tests the cloud.account module: mock provider, AWS static/env, GCP, Azure,
-# Kubernetes kubeconfig, and the cloud validate pipeline step.
-# Runs go unit tests from the workflow repo.
-set -euo pipefail
+# Scenario 25: Cloud Account.
+#
+# Demonstration-fidelity: this starts the real Workflow server from the
+# scenario config and validates configured cloud accounts through HTTP APIs.
+set -uo pipefail
 
-WORKFLOW_REPO="${WORKFLOW_REPO:-$(cd "$(dirname "$0")/../../.." && pwd)/../workflow}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:18125}"
+ACCOUNT_UNDER_TEST="${ACCOUNT_UNDER_TEST:-aws-staging}"
+EXPECTED_PROVIDER="${EXPECTED_PROVIDER:-mock}"
+EXPECTED_REGION="${EXPECTED_REGION:-us-west-2}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+CONFIG="$SCENARIO_DIR/config/app.yaml"
+
 PASS=0
 FAIL=0
+SERVER_PID=""
+DATA_DIR=""
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+finish() {
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ]
+}
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  [ -n "$DATA_DIR" ] && rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
 
-pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
-fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+find_repo() {
+  local env_value="$1"
+  shift
+  if [ -n "$env_value" ]; then
+    [ -d "$env_value" ] && printf '%s\n' "$env_value" && return 0
+    return 1
+  fi
+  local candidate
+  for candidate in "$@"; do
+    if [ -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_server() {
+  if [ -n "${WORKFLOW_SERVER:-}" ]; then
+    [ -x "$WORKFLOW_SERVER" ] && printf '%s\n' "$WORKFLOW_SERVER" && return 0
+    return 1
+  fi
+
+  local workflow_repo
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-${WORKFLOW_DIR:-}}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  mkdir -p "$workflow_repo/bin" || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/workflow-server ./cmd/server) >/dev/null 2>&1 || return 1
+  printf '%s\n' "$workflow_repo/bin/workflow-server"
+}
+
+wait_for_server() {
+  local url="$1"
+  local i
+  for i in $(seq 1 80); do
+    curl -fs "$url/healthz" >/dev/null 2>&1 && return 0
+    if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 0.25
+  done
+  return 1
+}
 
 echo ""
-echo "=== Scenario 25: Cloud Account (unit tests) ==="
+echo "=== Scenario 25: Cloud Account ==="
 echo ""
 
-if [ ! -d "$WORKFLOW_REPO" ]; then
-    fail "workflow repo not found at $WORKFLOW_REPO"
-    echo "Results: $PASS passed, $FAIL failed"
-    exit 1
+[ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
+if sed '/^[[:space:]]*#/d' "$SCRIPT_DIR/run.sh" | grep -Eq '(^|[;&|[:space:]])go[[:space:]]+test'; then
+  fail "scenario test should not delegate proof to Go package tests"
+else
+  pass "scenario test exercises the Workflow app boundary"
+fi
+if grep -A8 'name: validate' "$CONFIG" | grep -q 'account_from: account'; then
+  pass "validation pipeline selects account from client request"
+else
+  fail "validation pipeline should use account_from"
 fi
 
-while IFS= read -r line; do
-    if [[ "$line" =~ ^"--- PASS: " ]]; then
-        name="${line#--- PASS: }"
-        name="${name%% (*}"
-        pass "$name"
-    elif [[ "$line" =~ ^"--- FAIL: " ]]; then
-        name="${line#--- FAIL: }"
-        name="${name%% (*}"
-        fail "$name"
-    fi
-done < <(cd "$WORKFLOW_REPO" && go test ./module/ -v -count=1 -run "TestCloudAccount|TestCloudValidateStep" 2>&1)
+SERVER_BIN="$(resolve_server)"
+if [ "$?" -eq 0 ]; then
+  pass "workflow server binary is available"
+else
+  fail "workflow server unavailable; set WORKFLOW_SERVER or WORKFLOW_REPO"
+  finish
+  exit 1
+fi
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ]
+if ! DATA_DIR="$(mktemp -d)"; then
+  fail "could not create temporary data directory"
+  finish
+  exit 1
+fi
+
+SERVER_LOG="$SCRIPT_DIR/artifacts/last-server.log"
+mkdir -p "$(dirname "$SERVER_LOG")"
+"$SERVER_BIN" -config "$CONFIG" -data-dir "$DATA_DIR" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+if wait_for_server "$BASE_URL"; then
+  pass "workflow server started and served /healthz"
+else
+  fail "workflow server did not become ready; see $SERVER_LOG"
+  finish
+  exit 1
+fi
+
+LISTED="$(curl -fsS "$BASE_URL/api/cloud/accounts")" \
+  && pass "client listed configured cloud accounts through Workflow API" \
+  || fail "list cloud accounts API failed"
+if printf '%s' "$LISTED" | jq -e --arg account "$ACCOUNT_UNDER_TEST" '.count >= 3 and (.accounts[] | select(.name == $account))' >/dev/null 2>&1; then
+  pass "list response included the account under test"
+else
+  fail "list response missing account under test: $LISTED"
+fi
+if printf '%s' "$LISTED" | jq -e 'all(.accounts[]; (has("secretKey") or has("accessKey") or has("token")) | not)' >/dev/null 2>&1; then
+  pass "list response did not expose credential material"
+else
+  fail "list response exposed credential-looking keys: $LISTED"
+fi
+
+VALIDATE_BODY="$(jq -cn --arg account "$ACCOUNT_UNDER_TEST" '{account:$account}')"
+VALIDATED="$(curl -fsS -X POST "$BASE_URL/api/cloud/validate" -H 'Content-Type: application/json' -d "$VALIDATE_BODY")" \
+  && pass "client validated selected account through Workflow API" \
+  || fail "validate cloud account API failed"
+if printf '%s' "$VALIDATED" | jq -e \
+  --arg account "$ACCOUNT_UNDER_TEST" \
+  --arg provider "$EXPECTED_PROVIDER" \
+  --arg region "$EXPECTED_REGION" \
+  '.account == $account and .valid == true and .provider == $provider and .region == $region' >/dev/null 2>&1; then
+  pass "validate response matched selected account provider and region"
+else
+  fail "validate response mismatch: $VALIDATED"
+fi
+if printf '%s' "$VALIDATED" | jq -e 'has("secretKey") or has("accessKey") or has("token")' >/dev/null 2>&1; then
+  fail "validate response exposed credential-looking keys: $VALIDATED"
+else
+  pass "validate response did not expose credential material"
+fi
+
+FETCHED="$(curl -fsS "$BASE_URL/api/cloud/accounts/$ACCOUNT_UNDER_TEST")" \
+  && pass "client fetched selected account through Workflow API" \
+  || fail "get cloud account API failed"
+if printf '%s' "$FETCHED" | jq -e \
+  --arg account "$ACCOUNT_UNDER_TEST" \
+  --arg provider "$EXPECTED_PROVIDER" \
+  --arg region "$EXPECTED_REGION" \
+  '.account == $account and .valid == true and .provider == $provider and .region == $region' >/dev/null 2>&1; then
+  pass "get response matched selected account provider and region"
+else
+  fail "get response mismatch: $FETCHED"
+fi
+
+finish


### PR DESCRIPTION
## Summary
- replace scenario 25's package-test proxy with a real Workflow HTTP app proof
- expose list, validate, and get account APIs through the scenario app
- drive validation with a caller-selected account via `step.cloud_validate account_from`
- assert responses do not expose credential-looking fields

## Verification
- `WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/build-binary-config-from make test SCENARIO=25-cloud-account`
- Result: `ALL TESTS PASSED (13/13)`

The runner starts the real `workflow-server`, calls the scenario API with `curl`, validates a selected account from request data, and rejects package-test delegation in the scenario script.
