### PR TITLE
Exercise config-to-binary through Workflow app

### DIFF
--- a/scenarios.json
+++ b/scenarios.json
@@ -334,10 +334,10 @@
       "status": "passed",
       "namespace": "wf-scenario-26",
       "deployed": true,
-      "lastTested": "2026-03-28T22:22:03.290515Z",
+      "lastTested": "2026-07-01T17:15:12.436747Z",
       "lastResult": "pass",
-      "testCount": 12,
-      "passCount": 12,
+      "testCount": 18,
+      "passCount": 18,
       "failCount": 0,
       "notes": "Config-to-binary build step. Takes workflow config YAML and builds a standalone Go binary.",
       "blockers": []
@@ -1263,5 +1263,5 @@
       "blockers": []
     }
   },
-  "lastUpdated": "2026-07-01T16:51:25.738110Z"
+  "lastUpdated": "2026-07-01T17:15:12.436747Z"
 }

--- a/scenarios/26-config-to-binary/config/app.yaml
+++ b/scenarios/26-config-to-binary/config/app.yaml
@@ -2,8 +2,7 @@ modules:
   - name: server
     type: http.server
     config:
-      address: ":8080"
-
+      address: ":18126"
   - name: router
     type: http.router
     dependsOn: [server]
@@ -12,10 +11,9 @@ workflows:
   http:
     router: router
     server: server
-    routes: []
 
 pipelines:
-  healthz:
+  health:
     trigger:
       type: http
       config:
@@ -25,28 +23,31 @@ pipelines:
       - name: respond
         type: step.json_response
         config:
+          status: 200
           body:
             status: ok
+            scenario: "26-config-to-binary"
 
   build-binary-dry-run:
     trigger:
       type: http
       config:
-        path: /api/v1/build/binary
+        path: /api/build/binary
         method: POST
+        include_raw_body: true
     steps:
       - name: build
         type: step.build_binary
         config:
-          config_file: /config/app.yaml
-          module_path: generated-app
-          go_version: "1.22"
+          config_from: request_body
+          module_path: generated-scenario-app
+          go_version: "1.26"
           os: linux
           arch: amd64
           embed_config: true
           dry_run: true
-
       - name: respond
         type: step.json_response
         config:
+          status: 200
           body_from: steps.build

--- a/scenarios/26-config-to-binary/scenario.yaml
+++ b/scenarios/26-config-to-binary/scenario.yaml
@@ -3,10 +3,10 @@ id: "26-config-to-binary"
 category: C
 description: |
   Demonstrates step.build_binary which generates a self-contained Go project
-  from an embedded workflow config. Uses dry_run mode to verify generated code
-  without requiring a Go toolchain in the pod. Tests that POSTing a config
-  to a pipeline endpoint returns a valid Go project with go.mod, main.go,
-  and an embedded app.yaml.
+  from caller-supplied Workflow config. The test starts a real Workflow app,
+  POSTs two different app YAML documents to the build endpoint, and verifies
+  that dry-run output returns go.mod, main.go, and app.yaml content generated
+  by step.build_binary for each request.
 components:
   - workflow (engine)
   - cicd plugin (step.build_binary)

--- a/scenarios/26-config-to-binary/test/run.sh
+++ b/scenarios/26-config-to-binary/test/run.sh
@@ -1,39 +1,233 @@
 #!/usr/bin/env bash
-# Scenario 26: Config-to-Binary (step.build_binary)
-# Tests the build_binary pipeline step: dry-run output, generated go.mod/main.go,
-# embed directive, module path, and actual compilation.
-# Runs go unit tests from the workflow repo.
-set -euo pipefail
+# Scenario 26: Config-to-Binary.
+#
+# Demonstration-fidelity: this starts the real Workflow server from the
+# scenario config and drives step.build_binary through HTTP with caller-supplied
+# Workflow YAML.
+set -uo pipefail
 
-WORKFLOW_REPO="${WORKFLOW_REPO:-$(cd "$(dirname "$0")/../../.." && pwd)/../workflow}"
+BASE_URL="${BASE_URL:-http://127.0.0.1:18126}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCENARIO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCENARIO_DIR/../.." && pwd)"
+CONFIG="$SCENARIO_DIR/config/app.yaml"
+
 PASS=0
 FAIL=0
+SERVER_PID=""
+DATA_DIR=""
+REQUEST_A=""
+REQUEST_B=""
+RESPONSE_A=""
+RESPONSE_B=""
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+finish() {
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ]
+}
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  [ -n "$DATA_DIR" ] && rm -rf "$DATA_DIR"
+  [ -n "$REQUEST_A" ] && rm -f "$REQUEST_A"
+  [ -n "$REQUEST_B" ] && rm -f "$REQUEST_B"
+  [ -n "$RESPONSE_A" ] && rm -f "$RESPONSE_A"
+  [ -n "$RESPONSE_B" ] && rm -f "$RESPONSE_B"
+}
+trap cleanup EXIT
 
-pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
-fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+find_repo() {
+  local env_value="$1"
+  shift
+  if [ -n "$env_value" ]; then
+    [ -d "$env_value" ] && printf '%s\n' "$env_value" && return 0
+    return 1
+  fi
+  local candidate
+  for candidate in "$@"; do
+    if [ -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+resolve_server() {
+  if [ -n "${WORKFLOW_SERVER:-}" ]; then
+    [ -x "$WORKFLOW_SERVER" ] && printf '%s\n' "$WORKFLOW_SERVER" && return 0
+    return 1
+  fi
+
+  local workflow_repo
+  workflow_repo="$(find_repo "${WORKFLOW_REPO:-${WORKFLOW_DIR:-}}" "$REPO_ROOT/../workflow" "$REPO_ROOT/../../../workflow")" || return 1
+  mkdir -p "$workflow_repo/bin" || return 1
+  (cd "$workflow_repo" && GOWORK=off go build -o bin/workflow-server ./cmd/server) >/dev/null 2>&1 || return 1
+  printf '%s\n' "$workflow_repo/bin/workflow-server"
+}
+
+wait_for_server() {
+  local url="$1"
+  local i
+  for i in $(seq 1 80); do
+    curl -fs "$url/healthz" >/dev/null 2>&1 && return 0
+    if [ -n "$SERVER_PID" ] && ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      return 1
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+write_request_config() {
+  local path="$1"
+  local marker="$2"
+  cat >"$path" <<EOF
+modules:
+  - name: server
+    type: http.server
+    config:
+      address: ":0"
+  - name: router
+    type: http.router
+    dependsOn: [server]
+workflows:
+  http:
+    router: router
+    server: server
+pipelines:
+  health:
+    trigger:
+      type: http
+      config:
+        path: /healthz
+        method: GET
+    steps:
+      - name: respond
+        type: step.json_response
+        config:
+          status: 200
+          body:
+            status: ok
+            marker: "$marker"
+EOF
+}
+
+post_config() {
+  local request_file="$1"
+  local response_file="$2"
+  curl -fsS -X POST "$BASE_URL/api/build/binary" \
+    -H 'Content-Type: application/yaml' \
+    --data-binary "@$request_file" \
+    -o "$response_file"
+}
+
+assert_generated_response() {
+  local label="$1"
+  local request_file="$2"
+  local response_file="$3"
+
+  if jq -e '.dry_run == true and .module_path == "generated-scenario-app" and .go_version == "1.26" and .target_os == "linux" and .target_arch == "amd64"' "$response_file" >/dev/null; then
+    pass "$label response returned build metadata from step.build_binary"
+  else
+    fail "$label response missing expected build metadata: $(cat "$response_file")"
+  fi
+
+  if jq -e '.files | index("go.mod") and index("main.go") and index("app.yaml")' "$response_file" >/dev/null; then
+    pass "$label response listed generated project files"
+  else
+    fail "$label response missing generated file list: $(cat "$response_file")"
+  fi
+
+  if jq -e '.file_contents["go.mod"] | contains("module generated-scenario-app") and contains("go 1.26") and contains("github.com/GoCodeAlone/workflow")' "$response_file" >/dev/null; then
+    pass "$label response included generated go.mod"
+  else
+    fail "$label response go.mod content mismatch"
+  fi
+
+  if jq -e '.file_contents["main.go"] | contains("//go:embed app.yaml") and contains("workflow.NewStdEngine")' "$response_file" >/dev/null; then
+    pass "$label response included generated embedded-config main.go"
+  else
+    fail "$label response main.go content mismatch"
+  fi
+
+  if jq -e --rawfile expected "$request_file" '.file_contents["app.yaml"] == $expected' "$response_file" >/dev/null; then
+    pass "$label response embedded the caller-supplied app.yaml"
+  else
+    fail "$label response app.yaml did not match caller input"
+  fi
+}
 
 echo ""
-echo "=== Scenario 26: Config-to-Binary / step.build_binary (unit tests) ==="
+echo "=== Scenario 26: Config-to-Binary ==="
 echo ""
 
-if [ ! -d "$WORKFLOW_REPO" ]; then
-    fail "workflow repo not found at $WORKFLOW_REPO"
-    echo "Results: $PASS passed, $FAIL failed"
-    exit 1
+[ -f "$CONFIG" ] && pass "Workflow app config exists" || fail "Workflow app config missing"
+if sed '/^[[:space:]]*#/d' "$SCRIPT_DIR/run.sh" | grep -Eq '(^|[;&|[:space:]])go[[:space:]]+test'; then
+  fail "scenario test should not delegate proof to Go package tests"
+else
+  pass "scenario test exercises the Workflow app boundary"
+fi
+if grep -A12 'name: build' "$CONFIG" | grep -q 'config_from: request_body'; then
+  pass "build pipeline consumes caller-provided request body"
+else
+  fail "build pipeline should use config_from request_body"
 fi
 
-while IFS= read -r line; do
-    if [[ "$line" =~ ^"--- PASS: " ]]; then
-        name="${line#--- PASS: }"
-        name="${name%% (*}"
-        pass "$name"
-    elif [[ "$line" =~ ^"--- FAIL: " ]]; then
-        name="${line#--- FAIL: }"
-        name="${name%% (*}"
-        fail "$name"
-    fi
-done < <(cd "$WORKFLOW_REPO" && go test ./module/ -v -count=1 -run "TestBuildBinaryStep" 2>&1)
+SERVER_BIN="$(resolve_server)"
+if [ "$?" -eq 0 ]; then
+  pass "workflow server binary is available"
+else
+  fail "workflow server unavailable; set WORKFLOW_SERVER or WORKFLOW_REPO"
+  finish
+  exit 1
+fi
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ]
+if ! DATA_DIR="$(mktemp -d)"; then
+  fail "could not create temporary data directory"
+  finish
+  exit 1
+fi
+
+SERVER_LOG="$SCRIPT_DIR/artifacts/last-server.log"
+mkdir -p "$(dirname "$SERVER_LOG")"
+"$SERVER_BIN" -config "$CONFIG" -data-dir "$DATA_DIR" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+if wait_for_server "$BASE_URL"; then
+  pass "workflow server started and served /healthz"
+else
+  fail "workflow server did not become ready; see $SERVER_LOG"
+  finish
+  exit 1
+fi
+
+REQUEST_A="$(mktemp)"
+REQUEST_B="$(mktemp)"
+RESPONSE_A="$(mktemp)"
+RESPONSE_B="$(mktemp)"
+write_request_config "$REQUEST_A" "caller-alpha"
+write_request_config "$REQUEST_B" "caller-beta"
+
+post_config "$REQUEST_A" "$RESPONSE_A" \
+  && pass "client A generated project through Workflow API" \
+  || fail "client A build API failed"
+assert_generated_response "client A" "$REQUEST_A" "$RESPONSE_A"
+
+post_config "$REQUEST_B" "$RESPONSE_B" \
+  && pass "client B generated project through Workflow API" \
+  || fail "client B build API failed"
+assert_generated_response "client B" "$REQUEST_B" "$RESPONSE_B"
+
+if jq -e --rawfile a "$REQUEST_A" --rawfile b "$REQUEST_B" '.file_contents["app.yaml"] == $b and .file_contents["app.yaml"] != $a' "$RESPONSE_B" >/dev/null; then
+  pass "same pipeline generated different app.yaml for a different caller"
+else
+  fail "pipeline output appears hard-coded instead of caller-driven"
+fi
+
+finish


### PR DESCRIPTION
## Summary
- replace scenario 26's package-test proxy with a real Workflow app proof
- expose a build-binary HTTP endpoint that uses `include_raw_body` plus `step.build_binary config_from: request_body`
- post two different caller-supplied Workflow configs and assert generated `app.yaml` changes with each caller
- verify generated `go.mod`, `main.go`, and dry-run metadata come from the real step output

## Verification
- `WORKFLOW_DIR=/Users/jon/workspace/workflow/.worktrees/main-after-build-binary make test SCENARIO=26-config-to-binary`
- Workflow verification tree: `103f5526 Allow build_binary config from context (#984)`
- Result: `ALL TESTS PASSED (18/18)`

The runner starts the real `workflow-server`, calls the scenario API with `curl`, and rejects package-test delegation in the scenario script.
